### PR TITLE
make the google http-client an optional dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
             <version>1.19.0</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The google http-client is just necessary if you want to use MaxMind through the WebServiceClient. If just the local database is used, then the Jackson libraries will suffice.
