### PR TITLE
Add an interface for DatabaseReader to allow mocking

### DIFF
--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -28,7 +28,7 @@ import com.maxmind.geoip2.model.IspResponse;
  * Instances of this class provide a reader for the GeoIP2 database format. IP
  * addresses can be looked up using the <code>get</code> method.
  */
-public class DatabaseReader implements GeoIp2Provider, Closeable {
+public class DatabaseReader implements IDatabaseReader, Closeable {
 
     private final Reader reader;
 
@@ -207,6 +207,7 @@ public class DatabaseReader implements GeoIp2Provider, Closeable {
      * @throws GeoIp2Exception if there is an error looking up the IP
      * @throws IOException     if there is an IO error
      */
+    @Override
     public AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException,
             GeoIp2Exception {
         return this.get(ipAddress, AnonymousIpResponse.class, false, "GeoIP2-Anonymous-IP");
@@ -220,6 +221,7 @@ public class DatabaseReader implements GeoIp2Provider, Closeable {
      * @throws GeoIp2Exception if there is an error looking up the IP
      * @throws IOException     if there is an IO error
      */
+    @Override
     public ConnectionTypeResponse connectionType(InetAddress ipAddress)
             throws IOException, GeoIp2Exception {
         return this.get(ipAddress, ConnectionTypeResponse.class, false,
@@ -234,6 +236,7 @@ public class DatabaseReader implements GeoIp2Provider, Closeable {
      * @throws GeoIp2Exception if there is an error looking up the IP
      * @throws IOException     if there is an IO error
      */
+    @Override
     public DomainResponse domain(InetAddress ipAddress) throws IOException,
             GeoIp2Exception {
         return this
@@ -248,6 +251,7 @@ public class DatabaseReader implements GeoIp2Provider, Closeable {
      * @throws GeoIp2Exception if there is an error looking up the IP
      * @throws IOException     if there is an IO error
      */
+    @Override
     public IspResponse isp(InetAddress ipAddress) throws IOException,
             GeoIp2Exception {
         return this.get(ipAddress, IspResponse.class, false, "GeoIP2-ISP");

--- a/src/main/java/com/maxmind/geoip2/GeoIp2Provider.java
+++ b/src/main/java/com/maxmind/geoip2/GeoIp2Provider.java
@@ -4,7 +4,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.*;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.model.CountryResponse;
 
 public interface GeoIp2Provider {
 

--- a/src/main/java/com/maxmind/geoip2/GeoIp2Provider.java
+++ b/src/main/java/com/maxmind/geoip2/GeoIp2Provider.java
@@ -4,8 +4,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.CityResponse;
-import com.maxmind.geoip2.model.CountryResponse;
+import com.maxmind.geoip2.model.*;
 
 public interface GeoIp2Provider {
 

--- a/src/main/java/com/maxmind/geoip2/IDatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/IDatabaseReader.java
@@ -1,0 +1,56 @@
+package com.maxmind.geoip2;
+
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.AnonymousIpResponse;
+import com.maxmind.geoip2.model.ConnectionTypeResponse;
+import com.maxmind.geoip2.model.DomainResponse;
+import com.maxmind.geoip2.model.IspResponse;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+public interface IDatabaseReader extends GeoIp2Provider {
+    /**
+     * Look up an IP address in a GeoIP2 Anonymous IP.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return a AnonymousIpResponse for the requested IP address.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException     if there is an IO error
+     */
+    AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException,
+        GeoIp2Exception;
+
+    /**
+     * Look up an IP address in a GeoIP2 Connection Type database.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return a ConnectTypeResponse for the requested IP address.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException     if there is an IO error
+     */
+    ConnectionTypeResponse connectionType(InetAddress ipAddress)
+                    throws IOException, GeoIp2Exception;
+
+    /**
+     * Look up an IP address in a GeoIP2 Domain database.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return a DomainResponse for the requested IP address.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException     if there is an IO error
+     */
+    DomainResponse domain(InetAddress ipAddress) throws IOException,
+                            GeoIp2Exception;
+
+    /**
+     * Look up an IP address in a GeoIP2 ISP database.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return an IspResponse for the requested IP address.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException     if there is an IO error
+     */
+    IspResponse isp(InetAddress ipAddress) throws IOException,
+                                    GeoIp2Exception;
+}


### PR DESCRIPTION
Using an interface allows applications that use the DatabaseReader class to mock it in tests. The existing interface (GeoIp2Provider) only covers 2 methods. The new interface (IDatabaseReader) covers all 6 methods.