### PR TITLE
adding CityResponse.getLeastSpecificSubdivision

### DIFF
--- a/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
@@ -68,6 +68,19 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
         return this.subdivisions.get(this.subdivisions.size() - 1);
     }
 
+    /**
+     * @return An object representing the least specific subdivision returned. If
+     * the response did not contain any subdivisions, this method
+     * returns an empty {@link Subdivision} object.
+     */
+    @JsonIgnore
+    public Subdivision getLeastSpecificSubdivision() {
+        if (this.subdivisions.isEmpty()) {
+            return new Subdivision();
+        }
+        return this.subdivisions.get(0);
+    }
+    
     @Override
     public String toString() {
         return this.getClass().getSimpleName()

--- a/src/test/java/com/maxmind/geoip2/InsightsTest.java
+++ b/src/test/java/com/maxmind/geoip2/InsightsTest.java
@@ -51,6 +51,12 @@ public class InsightsTest {
                 "TT", this.insights.getMostSpecificSubdivision().getIsoCode());
     }
 
+    @Test
+    public void leastSpecificSubdivision() {
+    	assertEquals("Most specific subdivision returns first subdivision",
+    		"MN", this.insights.getLeastSpecificSubdivision().getIsoCode());
+    }
+
     @SuppressWarnings("boxing")
     @Test
     public void testTraits() {

--- a/src/test/java/com/maxmind/geoip2/NullTest.java
+++ b/src/test/java/com/maxmind/geoip2/NullTest.java
@@ -74,6 +74,11 @@ public class NullTest {
         assertNull(subdiv.getIsoCode());
         assertNull(subdiv.getConfidence());
 
+        Subdivision leastSpecificSubdiv = insights.getLeastSpecificSubdivision();
+        assertNotNull(leastSpecificSubdiv);
+        assertNull(leastSpecificSubdiv.getIsoCode());
+        assertNull(leastSpecificSubdiv.getConfidence());
+
         Traits traits = insights.getTraits();
         assertNotNull(traits);
         assertNull(traits.getAutonomousSystemNumber());


### PR DESCRIPTION
Similar to the getMostSpecificSubdivision - method I added a version for the first (i.e. least specific) subdivision