### PR TITLE
Configure jackson-databind to not suppress access checks.

### DIFF
--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -1,9 +1,6 @@
 package com.maxmind.geoip2;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.maxmind.db.InvalidDatabaseException;
 import com.maxmind.db.Metadata;
@@ -43,6 +40,7 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
                     "Unsupported Builder configuration: expected either File or URL");
         }
         this.om = new ObjectMapper();
+        this.om.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         this.om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
                 false);
         this.om.configure(

--- a/src/main/java/com/maxmind/geoip2/WebServiceClient.java
+++ b/src/main/java/com/maxmind/geoip2/WebServiceClient.java
@@ -7,6 +7,7 @@ import java.util.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpHeaders;
@@ -266,6 +267,7 @@ public class WebServiceClient implements GeoIp2Provider {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
                 false);
+        mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
 
         try {
             return mapper.reader(cls).with(inject).readValue(body);

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
@@ -16,9 +16,9 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
     AbstractCityResponse(MaxMind maxmind, Country registeredCountry, Traits traits, Country country, Continent continent,
                          Location location, List<Subdivision> subdivisions, RepresentedCountry representedCountry, Postal postal, City city) {
         super(continent, country, registeredCountry, maxmind, representedCountry, traits);
-        this.city = city != null ? city : City.empty();
-        this.location = location != null ? location : Location.empty();
-        this.postal = postal != null ? postal : Postal.empty();
+        this.city = city != null ? city : new City();
+        this.location = location != null ? location : new Location();
+        this.postal = postal != null ? postal : new Postal();
         this.subdivisions = subdivisions != null ? subdivisions : new ArrayList<Subdivision>();
     }
 
@@ -64,7 +64,7 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
     @JsonIgnore
     public Subdivision getMostSpecificSubdivision() {
         if (this.subdivisions.isEmpty()) {
-            return Subdivision.empty();
+            return new Subdivision();
         }
         return this.subdivisions.get(this.subdivisions.size() - 1);
     }
@@ -77,7 +77,7 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
     @JsonIgnore
     public Subdivision getLeastSpecificSubdivision() {
         if (this.subdivisions.isEmpty()) {
-            return Subdivision.empty();
+            return new Subdivision();
         }
         return this.subdivisions.get(0);
     }

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
@@ -4,27 +4,28 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.maxmind.geoip2.record.City;
-import com.maxmind.geoip2.record.Location;
-import com.maxmind.geoip2.record.Postal;
-import com.maxmind.geoip2.record.Subdivision;
+import com.maxmind.geoip2.record.*;
 
 abstract class AbstractCityResponse extends AbstractCountryResponse {
-    @JsonProperty
-    private final City city = new City();
-    @JsonProperty
-    private final Location location = new Location();
-    @JsonProperty
-    private final Postal postal = new Postal();
 
-    @JsonProperty("subdivisions")
-    private final ArrayList<Subdivision> subdivisions = new ArrayList<Subdivision>();
+    private final City city;
+    private final Location location;
+    private final Postal postal;
+    private final List<Subdivision> subdivisions;
+
+    AbstractCityResponse(MaxMind maxmind, Country registeredCountry, Traits traits, Country country, Continent continent,
+                         Location location, List<Subdivision> subdivisions, RepresentedCountry representedCountry, Postal postal, City city) {
+        super(continent, country, registeredCountry, maxmind, representedCountry, traits);
+        this.city = city != null ? city : City.empty();
+        this.location = location != null ? location : Location.empty();
+        this.postal = postal != null ? postal : Postal.empty();
+        this.subdivisions = subdivisions != null ? subdivisions : new ArrayList<Subdivision>();
+    }
 
     /**
      * @return City record for the requested IP address.
      */
-    public com.maxmind.geoip2.record.City getCity() {
+    public City getCity() {
         return this.city;
     }
 
@@ -63,7 +64,7 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
     @JsonIgnore
     public Subdivision getMostSpecificSubdivision() {
         if (this.subdivisions.isEmpty()) {
-            return new Subdivision();
+            return Subdivision.empty();
         }
         return this.subdivisions.get(this.subdivisions.size() - 1);
     }
@@ -76,7 +77,7 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
     @JsonIgnore
     public Subdivision getLeastSpecificSubdivision() {
         if (this.subdivisions.isEmpty()) {
-            return new Subdivision();
+            return Subdivision.empty();
         }
         return this.subdivisions.get(0);
     }

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
@@ -8,23 +8,40 @@ import com.maxmind.geoip2.record.RepresentedCountry;
 import com.maxmind.geoip2.record.Traits;
 
 abstract class AbstractCountryResponse extends AbstractResponse {
-    @JsonProperty
-    private final Continent continent = new Continent();
 
-    @JsonProperty
-    private final Country country = new Country();
+    private final Continent continent;
+    private final Country country;
+    private final Country registeredCountry;
+    private final MaxMind maxmind;
+    private final RepresentedCountry representedCountry;
+    private final Traits traits;
 
-    @JsonProperty("registered_country")
-    private final Country registeredCountry = new Country();
+    AbstractCountryResponse(Continent continent, Country country, Country registeredCountry, MaxMind maxmind, RepresentedCountry representedCountry, Traits traits) {
+        this.continent = continent != null ? continent : Continent.empty();
+        this.country = country != null ? country : Country.empty();
+        this.registeredCountry = registeredCountry != null ? registeredCountry : Country.empty();
+        this.maxmind = maxmind != null ? maxmind : MaxMind.empty();
+        this.representedCountry = representedCountry != null ? representedCountry : RepresentedCountry.empty();
+        this.traits = traits != null ? traits : Traits.empty();
+    }
 
+    /**
+     * @return MaxMind record containing data related to your account.
+     */
     @JsonProperty("maxmind")
-    private final MaxMind maxmind = new MaxMind();
+    public MaxMind getMaxMind() {
+        return this.maxmind;
+    }
 
-    @JsonProperty("represented_country")
-    private final RepresentedCountry representedCountry = new RepresentedCountry();
-
-    @JsonProperty
-    private final Traits traits = new Traits();
+    /**
+     * @return Registered country record for the requested IP address. This
+     * record represents the country where the ISP has registered a
+     * given IP block and may differ from the user's country.
+     */
+    @JsonProperty("registered_country")
+    public Country getRegisteredCountry() {
+        return this.registeredCountry;
+    }
 
     /**
      * @return Continent record for the requested IP address.
@@ -43,28 +60,12 @@ abstract class AbstractCountryResponse extends AbstractResponse {
     }
 
     /**
-     * @return MaxMind record containing data related to your account.
-     */
-    @JsonProperty("maxmind")
-    public MaxMind getMaxMind() {
-        return this.maxmind;
-    }
-
-    /**
-     * @return Registered country record for the requested IP address. This
-     * record represents the country where the ISP has registered a
-     * given IP block and may differ from the user's country.
-     */
-    public Country getRegisteredCountry() {
-        return this.registeredCountry;
-    }
-
-    /**
      * @return Represented country record for the requested IP address. The
      * represented country is used for things like military bases. It is
      * only present when the represented country differs from the
      * country.
      */
+    @JsonProperty("represented_country")
     public RepresentedCountry getRepresentedCountry() {
         return this.representedCountry;
     }

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
@@ -17,12 +17,12 @@ abstract class AbstractCountryResponse extends AbstractResponse {
     private final Traits traits;
 
     AbstractCountryResponse(Continent continent, Country country, Country registeredCountry, MaxMind maxmind, RepresentedCountry representedCountry, Traits traits) {
-        this.continent = continent != null ? continent : Continent.empty();
-        this.country = country != null ? country : Country.empty();
-        this.registeredCountry = registeredCountry != null ? registeredCountry : Country.empty();
-        this.maxmind = maxmind != null ? maxmind : MaxMind.empty();
-        this.representedCountry = representedCountry != null ? representedCountry : RepresentedCountry.empty();
-        this.traits = traits != null ? traits : Traits.empty();
+        this.continent = continent != null ? continent : new Continent();
+        this.country = country != null ? country : new Country();
+        this.registeredCountry = registeredCountry != null ? registeredCountry : new Country();
+        this.maxmind = maxmind != null ? maxmind : new MaxMind();
+        this.representedCountry = representedCountry != null ? representedCountry : new RepresentedCountry();
+        this.traits = traits != null ? traits : new Traits();
     }
 
     /**

--- a/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
@@ -28,6 +28,7 @@ public class AnonymousIpResponse extends AbstractResponse {
     /**
      * @return whether the IP address belongs to any sort of anonymous network.
      */
+    @JsonProperty("is_anonymous")
     public boolean isAnonymous() {
         return isAnonymous;
     }
@@ -35,6 +36,7 @@ public class AnonymousIpResponse extends AbstractResponse {
     /**
      * @return whether the IP address belongs to an anonymous VPN system.
      */
+    @JsonProperty("is_anonymous_vpn")
     public boolean isAnonymousVpn() {
         return isAnonymousVpn;
     }
@@ -42,6 +44,7 @@ public class AnonymousIpResponse extends AbstractResponse {
     /**
      * @return whether the IP address belongs to a hosting provider.
      */
+    @JsonProperty("is_hosting_provider")
     public boolean isHostingProvider() {
         return isHostingProvider;
     }
@@ -49,6 +52,7 @@ public class AnonymousIpResponse extends AbstractResponse {
     /**
      * @return whether the IP address belongs to a public proxy.
      */
+    @JsonProperty("is_public_proxy")
     public boolean isPublicProxy() {
         return isPublicProxy;
     }
@@ -56,6 +60,7 @@ public class AnonymousIpResponse extends AbstractResponse {
     /**
      * @return whether the IP address is a Tor exit node.
      */
+    @JsonProperty("is_tor_exit_node")
     public boolean isTorExitNode() {
         return isTorExitNode;
     }
@@ -64,6 +69,7 @@ public class AnonymousIpResponse extends AbstractResponse {
     /**
      * @return The IP address that the data in the model is for.
      */
+    @JsonProperty("ip_address")
     public String getIpAddress() {
         return this.ipAddress;
     }

--- a/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
@@ -7,24 +7,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class AnonymousIpResponse extends AbstractResponse {
 
-    @JsonProperty("is_anonymous")
-    private boolean isAnonymous;
+    private final boolean isAnonymous;
+    private final boolean isAnonymousVpn;
+    private final boolean isHostingProvider;
+    private final boolean isPublicProxy;
+    private final boolean isTorExitNode;
+    private final String ipAddress;
 
-    @JsonProperty("is_anonymous_vpn")
-    private boolean isAnonymousVpn;
-
-    @JsonProperty("is_hosting_provider")
-    private boolean isHostingProvider;
-
-    @JsonProperty("is_public_proxy")
-    private boolean isPublicProxy;
-
-    @JsonProperty("is_tor_exit_node")
-    private boolean isTorExitNode;
-
-    @JsonProperty("ip_address")
-    private String ipAddress;
-
+    public AnonymousIpResponse(@JsonProperty("is_anonymous") boolean isAnonymous, @JsonProperty("is_anonymous_vpn") boolean isAnonymousVpn,
+                               @JsonProperty("is_hosting_provider") boolean isHostingProvider, @JsonProperty("is_public_proxy") boolean isPublicProxy,
+                               @JsonProperty("is_tor_exit_node") boolean isTorExitNode, @JsonProperty("ip_address") String ipAddress) {
+        this.isAnonymous = isAnonymous;
+        this.isAnonymousVpn = isAnonymousVpn;
+        this.isHostingProvider = isHostingProvider;
+        this.isPublicProxy = isPublicProxy;
+        this.isTorExitNode = isTorExitNode;
+        this.ipAddress = ipAddress;
+    }
 
     /**
      * @return whether the IP address belongs to any sort of anonymous network.

--- a/src/main/java/com/maxmind/geoip2/model/CityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/CityResponse.java
@@ -1,5 +1,10 @@
 package com.maxmind.geoip2.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.maxmind.geoip2.record.*;
+
+import java.util.ArrayList;
+
 /**
  * <p>
  * This class provides a model for the data returned by the GeoIP2 Precision:
@@ -15,4 +20,13 @@ package com.maxmind.geoip2.model;
  * </p>
  */
 public final class CityResponse extends AbstractCityResponse {
+
+    public CityResponse(@JsonProperty("continent") Continent continent, @JsonProperty("country") Country country,
+                        @JsonProperty("registered_country") Country registeredCountry,
+                        @JsonProperty("maxmind") MaxMind maxmind,
+                        @JsonProperty("represented_country") RepresentedCountry representedCountry,
+                        @JsonProperty("traits") Traits traits, @JsonProperty("city") City city, @JsonProperty("location") Location location,
+                        @JsonProperty("postal") Postal postal, @JsonProperty("subdivisions") ArrayList<Subdivision> subdivisions) {
+        super(maxmind, registeredCountry, traits, country, continent, location, subdivisions, representedCountry, postal, city);
+    }
 }

--- a/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
@@ -33,11 +33,13 @@ public class ConnectionTypeResponse extends AbstractResponse {
         }
     }
 
-    @JsonProperty("connection_type")
-    private ConnectionType connectionType;
+    private final ConnectionType connectionType;
+    private final String ipAddress;
 
-    @JsonProperty("ip_address")
-    private String ipAddress;
+    public ConnectionTypeResponse(@JsonProperty("connection_type") ConnectionType connectionType, @JsonProperty("ip_address") String ipAddress) {
+        this.connectionType = connectionType;
+        this.ipAddress = ipAddress;
+    }
 
     /**
      * @return The connection type of the IP address.

--- a/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
@@ -44,6 +44,7 @@ public class ConnectionTypeResponse extends AbstractResponse {
     /**
      * @return The connection type of the IP address.
      */
+    @JsonProperty("connection_type")
     public ConnectionType getConnectionType() {
         return this.connectionType;
     }
@@ -51,6 +52,7 @@ public class ConnectionTypeResponse extends AbstractResponse {
     /**
      * @return The IP address that the data in the model is for.
      */
+    @JsonProperty("ip_address")
     public String getIpAddress() {
         return this.ipAddress;
     }

--- a/src/main/java/com/maxmind/geoip2/model/CountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/CountryResponse.java
@@ -1,5 +1,8 @@
 package com.maxmind.geoip2.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.maxmind.geoip2.record.*;
+
 /**
  * This class provides a model for the data returned by the GeoIP2 Precision:
  * Country end point.
@@ -8,4 +11,12 @@ package com.maxmind.geoip2.model;
  * Services</a>
  */
 public final class CountryResponse extends AbstractCountryResponse {
+
+    public CountryResponse(@JsonProperty("continent") Continent continent, @JsonProperty("country") Country country,
+                        @JsonProperty("registered_country") Country registeredCountry,
+                        @JsonProperty("maxmind") MaxMind maxmind,
+                        @JsonProperty("represented_country") RepresentedCountry representedCountry,
+                        @JsonProperty("traits") Traits traits) {
+        super(continent, country, registeredCountry, maxmind, representedCountry, traits);
+    }
 }

--- a/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
@@ -7,11 +7,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class DomainResponse extends AbstractResponse {
 
-    @JsonProperty
-    private String domain;
+    private final String domain;
+    private final String ipAddress;
 
-    @JsonProperty("ip_address")
-    private String ipAddress;
+    public DomainResponse(@JsonProperty("domain") String domain, @JsonProperty("ip_address") String ipAddress) {
+        this.domain = domain;
+        this.ipAddress = ipAddress;
+    }
 
     /**
      * @return the The second level domain associated with the IP address. This

--- a/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
@@ -27,6 +27,7 @@ public class DomainResponse extends AbstractResponse {
     /**
      * @return The IP address that the data in the model is for.
      */
+    @JsonProperty("ip_address")
     public String getIpAddress() {
         return this.ipAddress;
     }

--- a/src/main/java/com/maxmind/geoip2/model/InsightsResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/InsightsResponse.java
@@ -1,5 +1,10 @@
 package com.maxmind.geoip2.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.maxmind.geoip2.record.*;
+
+import java.util.List;
+
 /**
  * <p>
  * This class provides a model for the data returned by the GeoIP2 Precision:
@@ -15,4 +20,14 @@ package com.maxmind.geoip2.model;
  * </p>
  */
 public class InsightsResponse extends AbstractCityResponse {
+
+    public InsightsResponse(@JsonProperty("maxmind") MaxMind maxmind, @JsonProperty("registered_country") Country registeredCountry,
+                            @JsonProperty("traits") Traits traits, @JsonProperty("country") Country country,
+                            @JsonProperty("continent") Continent continent, @JsonProperty("location") Location location,
+                            @JsonProperty("subdivisions") List<Subdivision> subdivisions,
+                            @JsonProperty("represented_country") RepresentedCountry representedCountry,
+                            @JsonProperty("postal") Postal postal, @JsonProperty("city") City city) {
+        super(maxmind, registeredCountry, traits, country, continent, location, subdivisions, representedCountry, postal, city);
+    }
+
 }

--- a/src/main/java/com/maxmind/geoip2/model/IspResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/IspResponse.java
@@ -7,20 +7,22 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class IspResponse extends AbstractResponse {
 
-    @JsonProperty("autonomous_system_number")
-    private Integer autonomousSystemNumber;
+    private final Integer autonomousSystemNumber;
+    private final String autonomousSystemOrganization;
+    private final String isp;
+    private final String organization;
+    private final String ipAddress;
 
-    @JsonProperty("autonomous_system_organization")
-    private String autonomousSystemOrganization;
-
-    @JsonProperty
-    private String isp;
-
-    @JsonProperty
-    private String organization;
-
-    @JsonProperty("ip_address")
-    private String ipAddress;
+    public IspResponse(@JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
+                       @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,
+                       @JsonProperty("isp") String isp, @JsonProperty("organization") String organization,
+                       @JsonProperty("ip_address") String ipAddress) {
+        this.autonomousSystemNumber = autonomousSystemNumber;
+        this.autonomousSystemOrganization = autonomousSystemOrganization;
+        this.isp = isp;
+        this.organization = organization;
+        this.ipAddress = ipAddress;
+    }
 
     /**
      * @return The autonomous system number associated with the IP address.

--- a/src/main/java/com/maxmind/geoip2/model/IspResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/IspResponse.java
@@ -27,6 +27,7 @@ public class IspResponse extends AbstractResponse {
     /**
      * @return The autonomous system number associated with the IP address.
      */
+    @JsonProperty("autonomous_system_number")
     public Integer getAutonomousSystemNumber() {
         return this.autonomousSystemNumber;
     }
@@ -35,6 +36,7 @@ public class IspResponse extends AbstractResponse {
      * @return The organization associated with the registered autonomous system
      * number for the IP address
      */
+    @JsonProperty("autonomous_system_organization")
     public String getAutonomousSystemOrganization() {
         return this.autonomousSystemOrganization;
     }
@@ -56,6 +58,7 @@ public class IspResponse extends AbstractResponse {
     /**
      * @return The IP address that the data in the model is for.
      */
+    @JsonProperty("ip_address")
     public String getIpAddress() {
         return this.ipAddress;
     }

--- a/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
@@ -1,32 +1,32 @@
 package com.maxmind.geoip2.record;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JacksonInject;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * Abstract class for records with name maps.
  */
 public abstract class AbstractNamedRecord {
-    @JsonProperty
-    private final HashMap<String, String> names = new HashMap<String, String>();
-    @JsonProperty("geoname_id")
-    private Integer geoNameId;
 
-    @JacksonInject("locales")
-    private final List<String> locales = new ArrayList<String>();
+    private final Map<String, String> names;
+    private final Integer geoNameId;
+    private final List<String> locales;
 
-    AbstractNamedRecord() {
+    AbstractNamedRecord(Map<String, String> names, Integer geoNameId, List<String> locales) {
+        this.names = names != null ? names : new HashMap<String, String>();
+        this.geoNameId = geoNameId;
+        this.locales = locales != null ? locales : new ArrayList<String>();
     }
 
     /**
      * @return The GeoName ID for the city. This attribute is returned by all
      * end points.
      */
+    @JsonProperty("geoname_id")
     public Integer getGeoNameId() {
         return this.geoNameId;
     }
@@ -49,6 +49,7 @@ public abstract class AbstractNamedRecord {
      * @return A {@link Map} from locale codes to the name in that locale. This
      * attribute is returned by all end points.
      */
+    @JsonProperty("names")
     public Map<String, String> getNames() {
         return new HashMap<String, String>(this.names);
     }

--- a/src/main/java/com/maxmind/geoip2/record/City.java
+++ b/src/main/java/com/maxmind/geoip2/record/City.java
@@ -18,6 +18,10 @@ public final class City extends AbstractNamedRecord {
 
     private final Integer confidence;
 
+    public City() {
+        this(null, null, null, null);
+    }
+
     public City(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
                 @JacksonInject("locales") List<String> locales, @JsonProperty("confidence") Integer confidence) {
         super(names, geoNameId, locales);
@@ -33,8 +37,5 @@ public final class City extends AbstractNamedRecord {
         return this.confidence;
     }
 
-    public static City empty() {
-        return new City(null, null, null, null);
-    }
 
 }

--- a/src/main/java/com/maxmind/geoip2/record/City.java
+++ b/src/main/java/com/maxmind/geoip2/record/City.java
@@ -1,6 +1,10 @@
 package com.maxmind.geoip2.record;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * <p>
@@ -11,8 +15,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public final class City extends AbstractNamedRecord {
-    @JsonProperty
-    private Integer confidence;
+
+    private final Integer confidence;
+
+    public City(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
+                @JacksonInject("locales") List<String> locales, @JsonProperty("confidence") Integer confidence) {
+        super(names, geoNameId, locales);
+        this.confidence = confidence;
+    }
 
     /**
      * @return A value from 0-100 indicating MaxMind's confidence that the city
@@ -21,6 +31,10 @@ public final class City extends AbstractNamedRecord {
      */
     public Integer getConfidence() {
         return this.confidence;
+    }
+
+    public static City empty() {
+        return new City(null, null, null, null);
     }
 
 }

--- a/src/main/java/com/maxmind/geoip2/record/City.java
+++ b/src/main/java/com/maxmind/geoip2/record/City.java
@@ -3,8 +3,8 @@ package com.maxmind.geoip2.record;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
@@ -22,7 +22,7 @@ public final class City extends AbstractNamedRecord {
         this(null, null, null, null);
     }
 
-    public City(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
+    public City(@JsonProperty("names") Map<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
                 @JacksonInject("locales") List<String> locales, @JsonProperty("confidence") Integer confidence) {
         super(names, geoNameId, locales);
         this.confidence = confidence;

--- a/src/main/java/com/maxmind/geoip2/record/Continent.java
+++ b/src/main/java/com/maxmind/geoip2/record/Continent.java
@@ -1,6 +1,10 @@
 package com.maxmind.geoip2.record;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * <p>
@@ -11,8 +15,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public final class Continent extends AbstractNamedRecord {
-    @JsonProperty("code")
-    private String code;
+
+    private final String code;
+
+    public Continent(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("code") String code,
+                     @JsonProperty("geoname_id") Integer geoNameId, @JacksonInject("locales") List<String> locales) {
+        super(names, geoNameId, locales);
+        this.code = code;
+    }
 
     /**
      * @return A two character continent code like "NA" (North America) or "OC"
@@ -21,4 +31,9 @@ public final class Continent extends AbstractNamedRecord {
     public String getCode() {
         return this.code;
     }
+
+    public static Continent empty() {
+        return new Continent(null, null, null, null);
+    }
+
 }

--- a/src/main/java/com/maxmind/geoip2/record/Continent.java
+++ b/src/main/java/com/maxmind/geoip2/record/Continent.java
@@ -3,8 +3,8 @@ package com.maxmind.geoip2.record;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
@@ -22,7 +22,7 @@ public final class Continent extends AbstractNamedRecord {
         this(null, null, null, null);
     }
 
-    public Continent(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("code") String code,
+    public Continent(@JsonProperty("names") Map<String, String> names, @JsonProperty("code") String code,
                      @JsonProperty("geoname_id") Integer geoNameId, @JacksonInject("locales") List<String> locales) {
         super(names, geoNameId, locales);
         this.code = code;

--- a/src/main/java/com/maxmind/geoip2/record/Continent.java
+++ b/src/main/java/com/maxmind/geoip2/record/Continent.java
@@ -18,6 +18,10 @@ public final class Continent extends AbstractNamedRecord {
 
     private final String code;
 
+    public Continent() {
+        this(null, null, null, null);
+    }
+
     public Continent(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("code") String code,
                      @JsonProperty("geoname_id") Integer geoNameId, @JacksonInject("locales") List<String> locales) {
         super(names, geoNameId, locales);
@@ -30,10 +34,6 @@ public final class Continent extends AbstractNamedRecord {
      */
     public String getCode() {
         return this.code;
-    }
-
-    public static Continent empty() {
-        return new Continent(null, null, null, null);
     }
 
 }

--- a/src/main/java/com/maxmind/geoip2/record/Country.java
+++ b/src/main/java/com/maxmind/geoip2/record/Country.java
@@ -1,6 +1,10 @@
 package com.maxmind.geoip2.record;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * <p>
@@ -11,11 +15,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public class Country extends AbstractNamedRecord {
-    @JsonProperty
-    private Integer confidence;
 
-    @JsonProperty("iso_code")
-    private String isoCode;
+    private final Integer confidence;
+    private final String isoCode;
+
+    public Country(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
+                   @JsonProperty("iso_code") String isoCode, @JsonProperty("confidence") Integer confidence, @JacksonInject("locales") List<String> locales) {
+        super(names, geoNameId, locales);
+        this.confidence = confidence;
+        this.isoCode = isoCode;
+    }
 
     /**
      * @return A value from 0-100 indicating MaxMind's confidence that the
@@ -32,7 +41,13 @@ public class Country extends AbstractNamedRecord {
      * 3166-1 alpha code</a> for the country. This attribute is returned
      * by all end points.
      */
+    @JsonProperty("iso_code")
     public String getIsoCode() {
         return this.isoCode;
     }
+
+    public static Country empty() {
+        return new Country(null, null, null, null, null);
+    }
+
 }

--- a/src/main/java/com/maxmind/geoip2/record/Country.java
+++ b/src/main/java/com/maxmind/geoip2/record/Country.java
@@ -19,6 +19,10 @@ public class Country extends AbstractNamedRecord {
     private final Integer confidence;
     private final String isoCode;
 
+    public Country() {
+        this(null, null, null, null, null);
+    }
+
     public Country(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
                    @JsonProperty("iso_code") String isoCode, @JsonProperty("confidence") Integer confidence, @JacksonInject("locales") List<String> locales) {
         super(names, geoNameId, locales);
@@ -44,10 +48,6 @@ public class Country extends AbstractNamedRecord {
     @JsonProperty("iso_code")
     public String getIsoCode() {
         return this.isoCode;
-    }
-
-    public static Country empty() {
-        return new Country(null, null, null, null, null);
     }
 
 }

--- a/src/main/java/com/maxmind/geoip2/record/Country.java
+++ b/src/main/java/com/maxmind/geoip2/record/Country.java
@@ -3,8 +3,8 @@ package com.maxmind.geoip2.record;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
@@ -23,7 +23,7 @@ public class Country extends AbstractNamedRecord {
         this(null, null, null, null, null);
     }
 
-    public Country(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
+    public Country(@JsonProperty("names") Map<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
                    @JsonProperty("iso_code") String isoCode, @JsonProperty("confidence") Integer confidence, @JacksonInject("locales") List<String> locales) {
         super(names, geoNameId, locales);
         this.confidence = confidence;

--- a/src/main/java/com/maxmind/geoip2/record/Location.java
+++ b/src/main/java/com/maxmind/geoip2/record/Location.java
@@ -20,6 +20,10 @@ public class Location {
     private final Integer populationDensity;
     private final String timeZone;
 
+    public Location() {
+        this(null, null, null, null, null, null, null);
+    }
+
     public Location(@JsonProperty("average_income") Integer averageIncome, @JsonProperty("population_density") Integer populationDensity,
                     @JsonProperty("time_zone") String timeZone, @JsonProperty("accuracy_radius") Integer accuracyRadius,
                     @JsonProperty("metro_code") Integer metroCode, @JsonProperty("latitude") Double latitude,
@@ -120,10 +124,6 @@ public class Location {
                 + ", " : "")
                 + (this.timeZone != null ? "timeZone=" + this.timeZone : "")
                 + "]";
-    }
-
-    public static Location empty() {
-        return new Location(null, null, null, null, null, null, null);
     }
 
 }

--- a/src/main/java/com/maxmind/geoip2/record/Location.java
+++ b/src/main/java/com/maxmind/geoip2/record/Location.java
@@ -11,42 +11,77 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public class Location {
-    @JsonProperty("accuracy_radius")
-    private Integer accuracyRadius;
 
-    @JsonProperty("average_income")
-    private Integer averageIncome;
+    private final Integer accuracyRadius;
+    private final Integer averageIncome;
+    private final Double latitude;
+    private final Double longitude;
+    private final Integer metroCode;
+    private final Integer populationDensity;
+    private final String timeZone;
 
-    @JsonProperty
-    private Double latitude;
-
-    @JsonProperty
-    private Double longitude;
-
-    @JsonProperty("metro_code")
-    private Integer metroCode;
-
-    @JsonProperty("population_density")
-    private Integer populationDensity;
-
-    @JsonProperty("time_zone")
-    private String timeZone;
-
-    /**
-     * @return The radius in kilometers around the specified location where the
-     * IP address is likely to be. This attribute is only available from
-     * the Insights end point.
-     */
-    public Integer getAccuracyRadius() {
-        return this.accuracyRadius;
+    public Location(@JsonProperty("average_income") Integer averageIncome, @JsonProperty("population_density") Integer populationDensity,
+                    @JsonProperty("time_zone") String timeZone, @JsonProperty("accuracy_radius") Integer accuracyRadius,
+                    @JsonProperty("metro_code") Integer metroCode, @JsonProperty("latitude") Double latitude,
+                    @JsonProperty("longitude") Double longitude) {
+        this.accuracyRadius = accuracyRadius;
+        this.averageIncome = averageIncome;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.metroCode = metroCode;
+        this.populationDensity = populationDensity;
+        this.timeZone = timeZone;
     }
 
     /**
      * @return The average income in US dollars associated with the requested
      * IP address. This attribute is only available from the Insights end point.
      */
+    @JsonProperty("average_income")
     public Integer getAverageIncome() {
         return this.averageIncome;
+    }
+
+    /**
+     * @return The estimated population per square kilometer associated with the
+     * IP address. This attribute is only available from the Insights end point.
+     */
+    @JsonProperty("population_density")
+    public Integer getPopulationDensity() {
+        return this.populationDensity;
+    }
+
+    /**
+     * @return The time zone associated with location, as specified by the <a
+     * href="http://www.iana.org/time-zones">IANA Time Zone
+     * Database</a>, e.g., "America/New_York". This attribute is
+     * returned by all end points except the Country end point.
+     */
+    @JsonProperty("time_zone")
+    public String getTimeZone() {
+        return this.timeZone;
+    }
+
+    /**
+     * @return The radius in kilometers around the specified location where the
+     * IP address is likely to be. This attribute is only available from
+     * the Insights end point.
+     */
+    @JsonProperty("accuracy_radius")
+    public Integer getAccuracyRadius() {
+        return this.accuracyRadius;
+    }
+
+    /**
+     * @return The metro code of the location if the location is in the US.
+     * MaxMind returns the same metro codes as the <a href=
+     * "https://developers.google.com/adwords/api/docs/appendix/cities-DMAregions"
+     * >Google AdWords API</a>. This attribute is returned by all end
+     * points except the Country end point.
+     */
+    @JsonProperty("metro_code")
+    public Integer getMetroCode() {
+        return this.metroCode;
     }
 
     /**
@@ -65,35 +100,6 @@ public class Location {
      */
     public Double getLongitude() {
         return this.longitude;
-    }
-
-    /**
-     * @return The metro code of the location if the location is in the US.
-     * MaxMind returns the same metro codes as the <a href=
-     * "https://developers.google.com/adwords/api/docs/appendix/cities-DMAregions"
-     * >Google AdWords API</a>. This attribute is returned by all end
-     * points except the Country end point.
-     */
-    public Integer getMetroCode() {
-        return this.metroCode;
-    }
-
-    /**
-     * @return The estimated population per square kilometer associated with the
-     * IP address. This attribute is only available from the Insights end point.
-     */
-    public Integer getPopulationDensity() {
-        return this.populationDensity;
-    }
-
-    /**
-     * @return The time zone associated with location, as specified by the <a
-     * href="http://www.iana.org/time-zones">IANA Time Zone
-     * Database</a>, e.g., "America/New_York". This attribute is
-     * returned by all end points except the Country end point.
-     */
-    public String getTimeZone() {
-        return this.timeZone;
     }
 
     /*
@@ -115,4 +121,9 @@ public class Location {
                 + (this.timeZone != null ? "timeZone=" + this.timeZone : "")
                 + "]";
     }
+
+    public static Location empty() {
+        return new Location(null, null, null, null, null, null, null);
+    }
+
 }

--- a/src/main/java/com/maxmind/geoip2/record/MaxMind.java
+++ b/src/main/java/com/maxmind/geoip2/record/MaxMind.java
@@ -11,13 +11,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public final class MaxMind {
-    @JsonProperty("queries_remaining")
-    private Integer queriesRemaining;
+
+    private final Integer queriesRemaining;
+
+    public MaxMind(@JsonProperty("queries_remaining") Integer queriesRemaining) {
+        this.queriesRemaining = queriesRemaining;
+    }
 
     /**
      * @return The number of remaining queried in your account for the current
      * end point.
      */
+    @JsonProperty("queries_remaining")
     public Integer getQueriesRemaining() {
         return this.queriesRemaining;
     }
@@ -34,4 +39,9 @@ public final class MaxMind {
                 + this.getQueriesRemaining()
                 : "") + "]";
     }
+
+    public static MaxMind empty() {
+        return new MaxMind(null);
+    }
+
 }

--- a/src/main/java/com/maxmind/geoip2/record/MaxMind.java
+++ b/src/main/java/com/maxmind/geoip2/record/MaxMind.java
@@ -14,6 +14,10 @@ public final class MaxMind {
 
     private final Integer queriesRemaining;
 
+    public MaxMind() {
+        this(null);
+    }
+
     public MaxMind(@JsonProperty("queries_remaining") Integer queriesRemaining) {
         this.queriesRemaining = queriesRemaining;
     }
@@ -38,10 +42,6 @@ public final class MaxMind {
                 + (this.getQueriesRemaining() != null ? "getQueriesRemaining()="
                 + this.getQueriesRemaining()
                 : "") + "]";
-    }
-
-    public static MaxMind empty() {
-        return new MaxMind(null);
     }
 
 }

--- a/src/main/java/com/maxmind/geoip2/record/Postal.java
+++ b/src/main/java/com/maxmind/geoip2/record/Postal.java
@@ -18,6 +18,10 @@ public final class Postal {
     private final String code;
     private final Integer confidence;
 
+    public Postal() {
+        this(null, null);
+    }
+
     public Postal(@JsonProperty("code") String code, @JsonProperty("confidence") Integer confidence) {
         this.code = code;
         this.confidence = confidence;
@@ -50,10 +54,6 @@ public final class Postal {
     @Override
     public String toString() {
         return this.code != null ? this.code : "";
-    }
-
-    public static Postal empty() {
-        return new Postal(null, null);
     }
 
 }

--- a/src/main/java/com/maxmind/geoip2/record/Postal.java
+++ b/src/main/java/com/maxmind/geoip2/record/Postal.java
@@ -14,11 +14,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public final class Postal {
-    @JsonProperty
-    private String code;
 
-    @JsonProperty
-    private Integer confidence;
+    private final String code;
+    private final Integer confidence;
+
+    public Postal(@JsonProperty("code") String code, @JsonProperty("confidence") Integer confidence) {
+        this.code = code;
+        this.confidence = confidence;
+    }
 
     /**
      * @return The postal code of the location. Postal codes are not available
@@ -48,4 +51,9 @@ public final class Postal {
     public String toString() {
         return this.code != null ? this.code : "";
     }
+
+    public static Postal empty() {
+        return new Postal(null, null);
+    }
+
 }

--- a/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
+++ b/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
@@ -3,8 +3,8 @@ package com.maxmind.geoip2.record;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
@@ -24,7 +24,7 @@ public final class RepresentedCountry extends Country {
         this(null, null, null, null, null, null);
     }
 
-    public RepresentedCountry(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
+    public RepresentedCountry(@JsonProperty("names") Map<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
                               @JacksonInject("locales") List<String> locales, @JsonProperty("confidence") Integer confidence,
                               @JsonProperty("iso_code") String isoCode, @JsonProperty("type") String type) {
         super(names, geoNameId, isoCode, confidence, locales);

--- a/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
+++ b/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
@@ -1,6 +1,10 @@
 package com.maxmind.geoip2.record;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * <p>
@@ -13,8 +17,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public final class RepresentedCountry extends Country {
-    @JsonProperty
-    private String type;
+
+    private final String type;
+
+    public RepresentedCountry(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
+                              @JacksonInject("locales") List<String> locales, @JsonProperty("confidence") Integer confidence,
+                              @JsonProperty("iso_code") String isoCode, @JsonProperty("type") String type) {
+        super(names, geoNameId, isoCode, confidence, locales);
+        this.type = type;
+    }
 
     /**
      * @return A string indicating the type of entity that is representing the
@@ -24,4 +35,9 @@ public final class RepresentedCountry extends Country {
     public String getType() {
         return this.type;
     }
+
+    public static RepresentedCountry empty() {
+        return new RepresentedCountry(null, null, null, null, null, null);
+    }
+
 }

--- a/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
+++ b/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
@@ -20,6 +20,10 @@ public final class RepresentedCountry extends Country {
 
     private final String type;
 
+    public RepresentedCountry() {
+        this(null, null, null, null, null, null);
+    }
+
     public RepresentedCountry(@JsonProperty("names") HashMap<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
                               @JacksonInject("locales") List<String> locales, @JsonProperty("confidence") Integer confidence,
                               @JsonProperty("iso_code") String isoCode, @JsonProperty("type") String type) {
@@ -34,10 +38,6 @@ public final class RepresentedCountry extends Country {
      */
     public String getType() {
         return this.type;
-    }
-
-    public static RepresentedCountry empty() {
-        return new RepresentedCountry(null, null, null, null, null, null);
     }
 
 }

--- a/src/main/java/com/maxmind/geoip2/record/Subdivision.java
+++ b/src/main/java/com/maxmind/geoip2/record/Subdivision.java
@@ -18,6 +18,10 @@ public final class Subdivision extends AbstractNamedRecord {
     private final Integer confidence;
     private final String isoCode;
 
+    public Subdivision() {
+        this(null, null, null, new HashMap<String, String>(), new ArrayList<String>());
+    }
+
     public Subdivision(@JsonProperty("confidence") Integer confidence, @JsonProperty("iso_code") String isoCode,
                        @JsonProperty("geoname_id") Integer geoNameId, @JsonProperty("names") Map<String, String> names,
                        @JacksonInject("locales") List<String> locales) {
@@ -48,8 +52,4 @@ public final class Subdivision extends AbstractNamedRecord {
         return this.isoCode;
     }
 
-
-    public static Subdivision empty() {
-        return new Subdivision(null, null, null, new HashMap<String, String>(), new ArrayList<String>());
-    }
 }

--- a/src/main/java/com/maxmind/geoip2/record/Subdivision.java
+++ b/src/main/java/com/maxmind/geoip2/record/Subdivision.java
@@ -1,6 +1,9 @@
 package com.maxmind.geoip2.record;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.*;
 
 /**
  * <p>
@@ -11,17 +14,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public final class Subdivision extends AbstractNamedRecord {
-    @JsonProperty
-    private Integer confidence;
 
-    @JsonProperty("iso_code")
-    private String isoCode;
+    private final Integer confidence;
+    private final String isoCode;
+
+    public Subdivision(@JsonProperty("confidence") Integer confidence, @JsonProperty("iso_code") String isoCode,
+                       @JsonProperty("geoname_id") Integer geoNameId, @JsonProperty("names") Map<String, String> names,
+                       @JacksonInject("locales") List<String> locales) {
+        super(names, geoNameId, locales);
+        this.confidence = confidence;
+        this.isoCode = isoCode;
+    }
 
     /**
      * @return This is a value from 0-100 indicating MaxMind's confidence that
      * the subdivision is correct. This attribute is only available from
      * the Insights end point.
      */
+    @JsonProperty("confidence")
     public Integer getConfidence() {
         return this.confidence;
     }
@@ -33,7 +43,13 @@ public final class Subdivision extends AbstractNamedRecord {
      * 3166-2code</a>. This attribute is returned by all end points
      * except Country.
      */
+    @JsonProperty("iso_code")
     public String getIsoCode() {
         return this.isoCode;
+    }
+
+
+    public static Subdivision empty() {
+        return new Subdivision(null, null, null, new HashMap<String, String>(), new ArrayList<String>());
     }
 }

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -11,32 +11,51 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * </p>
  */
 public final class Traits {
-    @JsonProperty("autonomous_system_number")
-    private Integer autonomousSystemNumber;
 
-    @JsonProperty("autonomous_system_organization")
-    private String autonomousSystemOrganization;
+    private final Integer autonomousSystemNumber;
+    private final String autonomousSystemOrganization;
+    private final String domain;
+    private final String ipAddress;
+    private final boolean anonymousProxy;
+    private final boolean satelliteProvider;
+    private final String isp;
+    private final String organization;
+    private final String userType;
 
-    @JsonProperty
-    private String domain;
+    public Traits(@JsonProperty("is_anonymous_proxy") boolean anonymousProxy,
+                  @JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
+                  @JsonProperty("isp") String isp, @JsonProperty("ip_address") String ipAddress,
+                  @JsonProperty("is_satellite_provider") boolean satelliteProvider,
+                  @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,
+                  @JsonProperty("user_type") String userType,
+                  @JsonProperty("organization") String organization,
+                  @JsonProperty("domain") String domain) {
+        this.autonomousSystemNumber = autonomousSystemNumber;
+        this.autonomousSystemOrganization = autonomousSystemOrganization;
+        this.domain = domain;
+        this.ipAddress = ipAddress;
+        this.anonymousProxy = anonymousProxy;
+        this.satelliteProvider = satelliteProvider;
+        this.isp = isp;
+        this.organization = organization;
+        this.userType = userType;
+    }
 
-    @JsonProperty("ip_address")
-    private String ipAddress;
-
+    /**
+     * @return This is true if the IP is an anonymous proxy. This attribute is
+     * returned by all end points.
+     * @see <a href="http://dev.maxmind.com/faq/geoip#anonproxy">MaxMind's GeoIP
+     * FAQ</a>
+     *
+     * @deprecated Use our
+     * <a href="https://www.maxmind.com/en/geoip2-anonymous-ip-database">GeoIP2
+     * Anonymous IP database</a> instead.
+     */
+    @Deprecated
     @JsonProperty("is_anonymous_proxy")
-    private boolean anonymousProxy;
-
-    @JsonProperty("is_satellite_provider")
-    private boolean satelliteProvider;
-
-    @JsonProperty
-    private String isp;
-
-    @JsonProperty
-    private String organization;
-
-    @JsonProperty("user_type")
-    private String userType;
+    public boolean isAnonymousProxy() {
+        return this.anonymousProxy;
+    }
 
     /**
      * @return The <a
@@ -45,42 +64,11 @@ public final class Traits {
      * This attribute is only available from the City and Insights web
      * service end points.
      */
+    @JsonProperty("autonomous_system_number")
     public Integer getAutonomousSystemNumber() {
         return this.autonomousSystemNumber;
     }
 
-    /**
-     * @return The organization associated with the registered <a
-     * href="http://en.wikipedia.org/wiki/Autonomous_system_(Internet)"
-     * >autonomous system number</a> for the IP address. This attribute
-     * is only available from the City and Insights web service end
-     * points.
-     */
-    public String getAutonomousSystemOrganization() {
-        return this.autonomousSystemOrganization;
-    }
-
-    /**
-     * @return The second level domain associated with the IP address. This will
-     * be something like "example.com" or "example.co.uk", not
-     * "foo.example.com". This attribute is only available from the City
-     * and Insights web service end points.
-     */
-    public String getDomain() {
-        return this.domain;
-    }
-
-    /**
-     * @return The IP address that the data in the model is for. If you
-     * performed a "me" lookup against the web service, this will be the
-     * externally routable IP address for the system the code is running
-     * on. If the system is behind a NAT, this may differ from the IP
-     * address locally assigned to it. This attribute is returned by all
-     * end points.
-     */
-    public String getIpAddress() {
-        return this.ipAddress;
-    }
 
     /**
      * @return The name of the ISP associated with the IP address. This
@@ -92,12 +80,41 @@ public final class Traits {
     }
 
     /**
-     * @return The name of the organization associated with the IP address. This
-     * attribute is only available from the City and Insights web
-     * service end points.
+     * @return The IP address that the data in the model is for. If you
+     * performed a "me" lookup against the web service, this will be the
+     * externally routable IP address for the system the code is running
+     * on. If the system is behind a NAT, this may differ from the IP
+     * address locally assigned to it. This attribute is returned by all
+     * end points.
      */
-    public String getOrganization() {
-        return this.organization;
+    @JsonProperty("ip_address")
+    public String getIpAddress() {
+        return this.ipAddress;
+    }
+
+    /**
+     * @return This is true if the IP belong to a satellite internet provider.
+     * This attribute is returned by all end points.
+     *
+     * @deprecated Due to increased mobile usage, we have insufficient data to
+     * maintain this field.
+     */
+    @Deprecated
+    @JsonProperty("is_satellite_provider")
+    public boolean isSatelliteProvider() {
+        return this.satelliteProvider;
+    }
+
+    /**
+     * @return The organization associated with the registered <a
+     * href="http://en.wikipedia.org/wiki/Autonomous_system_(Internet)"
+     * >autonomous system number</a> for the IP address. This attribute
+     * is only available from the City and Insights web service end
+     * points.
+     */
+    @JsonProperty("autonomous_system_organization")
+    public String getAutonomousSystemOrganization() {
+        return this.autonomousSystemOrganization;
     }
 
     /**
@@ -126,35 +143,30 @@ public final class Traits {
      * This attribute is only available from the Insights end point.
      * </p>
      */
+    @JsonProperty("user_type")
     public String getUserType() {
         return this.userType;
     }
 
     /**
-     * @return This is true if the IP is an anonymous proxy. This attribute is
-     * returned by all end points.
-     * @see <a href="http://dev.maxmind.com/faq/geoip#anonproxy">MaxMind's GeoIP
-     * FAQ</a>
-     *
-     * @deprecated Use our
-     * <a href="https://www.maxmind.com/en/geoip2-anonymous-ip-database">GeoIP2
-     * Anonymous IP database</a> instead.
+     * @return The name of the organization associated with the IP address. This
+     * attribute is only available from the City and Insights web
+     * service end points.
      */
-    @Deprecated
-    public boolean isAnonymousProxy() {
-        return this.anonymousProxy;
+    @JsonProperty
+    public String getOrganization() {
+        return this.organization;
     }
 
     /**
-     * @return This is true if the IP belong to a satellite internet provider.
-     * This attribute is returned by all end points.
-     *
-     * @deprecated Due to increased mobile usage, we have insufficient data to
-     * maintain this field.
+     * @return The second level domain associated with the IP address. This will
+     * be something like "example.com" or "example.co.uk", not
+     * "foo.example.com". This attribute is only available from the City
+     * and Insights web service end points.
      */
-    @Deprecated
-    public boolean isSatelliteProvider() {
-        return this.satelliteProvider;
+    @JsonProperty
+    public String getDomain() {
+        return this.domain;
     }
 
     /*
@@ -184,5 +196,9 @@ public final class Traits {
                 + this.organization + ", " : "")
                 + (this.userType != null ? "userType=" + this.userType : "")
                 + "]";
+    }
+
+    public static Traits empty() {
+        return new Traits(false, null, null, null, false, null, null, null, null);
     }
 }

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -22,6 +22,10 @@ public final class Traits {
     private final String organization;
     private final String userType;
 
+    public Traits() {
+        this(false, null, null, null, false, null, null, null, null);
+    }
+
     public Traits(@JsonProperty("is_anonymous_proxy") boolean anonymousProxy,
                   @JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
                   @JsonProperty("isp") String isp, @JsonProperty("ip_address") String ipAddress,
@@ -198,7 +202,4 @@ public final class Traits {
                 + "]";
     }
 
-    public static Traits empty() {
-        return new Traits(false, null, null, null, false, null, null, null, null);
-    }
 }


### PR DESCRIPTION
Because of this change all model classes have now annotated constructors.

This allows geoip2 to be run in secured environments without enabling suppressAccessChecks permission.

PR for #51