### PR TITLE
Add serialization tests and code cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,17 +50,17 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
-            <version>1.20.0</version>
+            <version>1.21.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.5.3</version>
+            <version>2.6.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-objects</artifactId>
-            <version>2.5.4</version>
+            <version>2.6.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.5.3</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-objects</artifactId>
+            <version>2.5.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
@@ -16,10 +16,10 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a AnonymousIpResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException     if there is an IO error
+     * @throws java.io.IOException                          if there is an IO error
      */
     AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException,
-        GeoIp2Exception;
+            GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 Connection Type database.
@@ -27,10 +27,10 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a ConnectTypeResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException     if there is an IO error
+     * @throws java.io.IOException                          if there is an IO error
      */
     ConnectionTypeResponse connectionType(InetAddress ipAddress)
-                    throws IOException, GeoIp2Exception;
+            throws IOException, GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 Domain database.
@@ -38,10 +38,10 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a DomainResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException     if there is an IO error
+     * @throws java.io.IOException                          if there is an IO error
      */
     DomainResponse domain(InetAddress ipAddress) throws IOException,
-                            GeoIp2Exception;
+            GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 ISP database.
@@ -49,8 +49,8 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return an IspResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException     if there is an IO error
+     * @throws java.io.IOException                          if there is an IO error
      */
     IspResponse isp(InetAddress ipAddress) throws IOException,
-                                    GeoIp2Exception;
+            GeoIp2Exception;
 }

--- a/src/main/java/com/maxmind/geoip2/GeoIp2Provider.java
+++ b/src/main/java/com/maxmind/geoip2/GeoIp2Provider.java
@@ -1,11 +1,11 @@
 package com.maxmind.geoip2;
 
-import java.io.IOException;
-import java.net.InetAddress;
-
 import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.model.CountryResponse;
+
+import java.io.IOException;
+import java.net.InetAddress;
 
 public interface GeoIp2Provider {
 

--- a/src/main/java/com/maxmind/geoip2/WebServiceClient.java
+++ b/src/main/java/com/maxmind/geoip2/WebServiceClient.java
@@ -1,31 +1,23 @@
 package com.maxmind.geoip2;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.*;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpRequestFactory;
-import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.HttpResponseException;
-import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.*;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.maxmind.geoip2.exception.AddressNotFoundException;
-import com.maxmind.geoip2.exception.AuthenticationException;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.exception.HttpException;
-import com.maxmind.geoip2.exception.InvalidRequestException;
-import com.maxmind.geoip2.exception.OutOfQueriesException;
+import com.maxmind.geoip2.exception.*;
 import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.model.CountryResponse;
 import com.maxmind.geoip2.model.InsightsResponse;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
@@ -13,9 +13,19 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
     private final Postal postal;
     private final List<Subdivision> subdivisions;
 
-    AbstractCityResponse(MaxMind maxmind, Country registeredCountry, Traits traits, Country country, Continent continent,
-                         Location location, List<Subdivision> subdivisions, RepresentedCountry representedCountry, Postal postal, City city) {
-        super(continent, country, registeredCountry, maxmind, representedCountry, traits);
+    AbstractCityResponse(
+            City city,
+            Continent continent,
+            Country country,
+            Location location,
+            MaxMind maxmind,
+            Postal postal,
+            Country registeredCountry,
+            RepresentedCountry representedCountry,
+            List<Subdivision> subdivisions,
+            Traits traits
+    ) {
+        super(continent, country, maxmind, registeredCountry, representedCountry, traits);
         this.city = city != null ? city : new City();
         this.location = location != null ? location : new Location();
         this.postal = postal != null ? postal : new Postal();

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
@@ -6,7 +6,7 @@ import com.maxmind.geoip2.record.*;
 import java.util.ArrayList;
 import java.util.List;
 
-abstract class AbstractCityResponse extends AbstractCountryResponse {
+public abstract class AbstractCityResponse extends AbstractCountryResponse {
 
     private final City city;
     private final Location location;

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
@@ -13,6 +13,10 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
     private final Postal postal;
     private final List<Subdivision> subdivisions;
 
+    AbstractCityResponse() {
+        this(null, null, null, null, null, null, null, null, null, null);
+    }
+
     AbstractCityResponse(
             City city,
             Continent continent,

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
@@ -1,10 +1,10 @@
 package com.maxmind.geoip2.model;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.maxmind.geoip2.record.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 abstract class AbstractCityResponse extends AbstractCountryResponse {
 
@@ -95,7 +95,7 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
         }
         return this.subdivisions.get(0);
     }
-    
+
     @Override
     public String toString() {
         return this.getClass().getSimpleName()

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCityResponse.java
@@ -95,31 +95,4 @@ abstract class AbstractCityResponse extends AbstractCountryResponse {
         }
         return this.subdivisions.get(0);
     }
-
-    @Override
-    public String toString() {
-        return this.getClass().getSimpleName()
-                + " ["
-                + (this.getCity() != null ? "getCity()=" + this.getCity()
-                + ", " : "")
-                + (this.getLocation() != null ? "getLocation()="
-                + this.getLocation() + ", " : "")
-                + (this.getPostal() != null ? "getPostal()=" + this.getPostal()
-                + ", " : "")
-                + (this.getSubdivisions() != null ? "getSubdivisionsList()="
-                + this.getSubdivisions() + ", " : "")
-                + (this.getContinent() != null ? "getContinent()="
-                + this.getContinent() + ", " : "")
-                + (this.getCountry() != null ? "getCountry()="
-                + this.getCountry() + ", " : "")
-                + (this.getRegisteredCountry() != null ? "getRegisteredCountry()="
-                + this.getRegisteredCountry() + ", "
-                : "")
-                + (this.getRepresentedCountry() != null ? "getRepresentedCountry()="
-                + this.getRepresentedCountry() + ", "
-                : "")
-                + (this.getTraits() != null ? "getTraits()=" + this.getTraits()
-                : "") + "]";
-    }
-
 }

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
@@ -16,6 +16,10 @@ abstract class AbstractCountryResponse extends AbstractResponse {
     private final RepresentedCountry representedCountry;
     private final Traits traits;
 
+    AbstractCountryResponse() {
+        this(null, null, null, null, null, null);
+    }
+
     AbstractCountryResponse(
             Continent continent,
             Country country,

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
@@ -16,7 +16,14 @@ abstract class AbstractCountryResponse extends AbstractResponse {
     private final RepresentedCountry representedCountry;
     private final Traits traits;
 
-    AbstractCountryResponse(Continent continent, Country country, Country registeredCountry, MaxMind maxmind, RepresentedCountry representedCountry, Traits traits) {
+    AbstractCountryResponse(
+            Continent continent,
+            Country country,
+            MaxMind maxmind,
+            Country registeredCountry,
+            RepresentedCountry representedCountry,
+            Traits traits
+    ) {
         this.continent = continent != null ? continent : new Continent();
         this.country = country != null ? country : new Country();
         this.registeredCountry = registeredCountry != null ? registeredCountry : new Country();

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
@@ -84,25 +84,16 @@ abstract class AbstractCountryResponse extends AbstractResponse {
         return this.traits;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
-        return "Country ["
-                + (this.getContinent() != null ? "getContinent()="
-                + this.getContinent() + ", " : "")
-                + (this.getCountry() != null ? "getCountry()="
-                + this.getCountry() + ", " : "")
-                + (this.getRegisteredCountry() != null ? "getRegisteredCountry()="
-                + this.getRegisteredCountry() + ", "
-                : "")
-                + (this.getRepresentedCountry() != null ? "getRepresentedCountry()="
-                + this.getRepresentedCountry() + ", "
-                : "")
-                + (this.getTraits() != null ? "getTraits()=" + this.getTraits()
-                : "") + "]";
+        final StringBuilder sb = new StringBuilder("AbstractCountryResponse{");
+        sb.append("continent=").append(continent);
+        sb.append(", country=").append(country);
+        sb.append(", registeredCountry=").append(registeredCountry);
+        sb.append(", maxmind=").append(maxmind);
+        sb.append(", representedCountry=").append(representedCountry);
+        sb.append(", traits=").append(traits);
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
@@ -3,7 +3,7 @@ package com.maxmind.geoip2.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.maxmind.geoip2.record.*;
 
-abstract class AbstractCountryResponse extends AbstractResponse {
+public abstract class AbstractCountryResponse extends AbstractResponse {
 
     private final Continent continent;
     private final Country country;

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
@@ -1,11 +1,7 @@
 package com.maxmind.geoip2.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.maxmind.geoip2.record.Continent;
-import com.maxmind.geoip2.record.Country;
-import com.maxmind.geoip2.record.MaxMind;
-import com.maxmind.geoip2.record.RepresentedCountry;
-import com.maxmind.geoip2.record.Traits;
+import com.maxmind.geoip2.record.*;
 
 abstract class AbstractCountryResponse extends AbstractResponse {
 

--- a/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractCountryResponse.java
@@ -83,17 +83,4 @@ abstract class AbstractCountryResponse extends AbstractResponse {
     public Traits getTraits() {
         return this.traits;
     }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("AbstractCountryResponse{");
-        sb.append("continent=").append(continent);
-        sb.append(", country=").append(country);
-        sb.append(", registeredCountry=").append(registeredCountry);
-        sb.append(", maxmind=").append(maxmind);
-        sb.append(", representedCountry=").append(representedCountry);
-        sb.append(", traits=").append(traits);
-        sb.append('}');
-        return sb.toString();
-    }
 }

--- a/src/main/java/com/maxmind/geoip2/model/AbstractResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractResponse.java
@@ -1,9 +1,9 @@
 package com.maxmind.geoip2.model;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
 
 public abstract class AbstractResponse {
 

--- a/src/main/java/com/maxmind/geoip2/model/AbstractResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractResponse.java
@@ -1,6 +1,7 @@
 package com.maxmind.geoip2.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
@@ -16,6 +17,7 @@ public abstract class AbstractResponse {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(Include.NON_NULL);
         mapper.setSerializationInclusion(Include.NON_EMPTY);
+        mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         return mapper.writeValueAsString(this);
     }
 

--- a/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
@@ -14,6 +14,10 @@ public class AnonymousIpResponse extends AbstractResponse {
     private final boolean isTorExitNode;
     private final String ipAddress;
 
+    AnonymousIpResponse() {
+        this(null, false, false, false, false, false);
+    }
+
     public AnonymousIpResponse(
             @JsonProperty("ip_address") String ipAddress,
             @JsonProperty("is_anonymous") boolean isAnonymous,

--- a/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
@@ -82,16 +82,4 @@ public class AnonymousIpResponse extends AbstractResponse {
     public String getIpAddress() {
         return this.ipAddress;
     }
-
-    @Override
-    public String toString() {
-        return "AnonymousIpResponse[" +
-                "isAnonymous=" + isAnonymous +
-                ", isAnonymousVpn=" + isAnonymousVpn +
-                ", isHostingProvider=" + isHostingProvider +
-                ", isPublicProxy=" + isPublicProxy +
-                ", isTorExitNode=" + isTorExitNode +
-                ", ipAddress='" + ipAddress + '\'' +
-                ']';
-    }
 }

--- a/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
@@ -14,9 +14,14 @@ public class AnonymousIpResponse extends AbstractResponse {
     private final boolean isTorExitNode;
     private final String ipAddress;
 
-    public AnonymousIpResponse(@JsonProperty("is_anonymous") boolean isAnonymous, @JsonProperty("is_anonymous_vpn") boolean isAnonymousVpn,
-                               @JsonProperty("is_hosting_provider") boolean isHostingProvider, @JsonProperty("is_public_proxy") boolean isPublicProxy,
-                               @JsonProperty("is_tor_exit_node") boolean isTorExitNode, @JsonProperty("ip_address") String ipAddress) {
+    public AnonymousIpResponse(
+            @JsonProperty("ip_address") String ipAddress,
+            @JsonProperty("is_anonymous") boolean isAnonymous,
+            @JsonProperty("is_anonymous_vpn") boolean isAnonymousVpn,
+            @JsonProperty("is_hosting_provider") boolean isHostingProvider,
+            @JsonProperty("is_public_proxy") boolean isPublicProxy,
+            @JsonProperty("is_tor_exit_node") boolean isTorExitNode
+    ) {
         this.isAnonymous = isAnonymous;
         this.isAnonymousVpn = isAnonymousVpn;
         this.isHostingProvider = isHostingProvider;

--- a/src/main/java/com/maxmind/geoip2/model/CityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/CityResponse.java
@@ -21,12 +21,19 @@ import java.util.ArrayList;
  */
 public final class CityResponse extends AbstractCityResponse {
 
-    public CityResponse(@JsonProperty("continent") Continent continent, @JsonProperty("country") Country country,
-                        @JsonProperty("registered_country") Country registeredCountry,
-                        @JsonProperty("maxmind") MaxMind maxmind,
-                        @JsonProperty("represented_country") RepresentedCountry representedCountry,
-                        @JsonProperty("traits") Traits traits, @JsonProperty("city") City city, @JsonProperty("location") Location location,
-                        @JsonProperty("postal") Postal postal, @JsonProperty("subdivisions") ArrayList<Subdivision> subdivisions) {
-        super(maxmind, registeredCountry, traits, country, continent, location, subdivisions, representedCountry, postal, city);
+    public CityResponse(
+            @JsonProperty("city") City city,
+            @JsonProperty("continent") Continent continent,
+            @JsonProperty("country") Country country,
+            @JsonProperty("location") Location location,
+            @JsonProperty("maxmind") MaxMind maxmind,
+            @JsonProperty("postal") Postal postal,
+            @JsonProperty("registered_country") Country registeredCountry,
+            @JsonProperty("represented_country") RepresentedCountry representedCountry,
+            @JsonProperty("subdivisions") ArrayList<Subdivision> subdivisions,
+            @JsonProperty("traits") Traits traits
+    ) {
+        super(city, continent, country, location, maxmind, postal, registeredCountry,
+                representedCountry, subdivisions, traits);
     }
 }

--- a/src/main/java/com/maxmind/geoip2/model/CityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/CityResponse.java
@@ -21,6 +21,10 @@ import java.util.ArrayList;
  */
 public final class CityResponse extends AbstractCityResponse {
 
+    CityResponse() {
+        this(null, null, null, null, null, null, null, null, null, null);
+    }
+
     public CityResponse(
             @JsonProperty("city") City city,
             @JsonProperty("continent") Continent continent,

--- a/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
@@ -64,15 +64,4 @@ public class ConnectionTypeResponse extends AbstractResponse {
     public String getIpAddress() {
         return this.ipAddress;
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "ConnectionTypeResponse [connectionType=" + this.connectionType
-                + ", ipAddress=" + this.ipAddress + "]";
-    }
 }

--- a/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
@@ -36,6 +36,11 @@ public class ConnectionTypeResponse extends AbstractResponse {
     private final ConnectionType connectionType;
     private final String ipAddress;
 
+
+    ConnectionTypeResponse() {
+        this(null, null);
+    }
+
     public ConnectionTypeResponse(
             @JsonProperty("connection_type") ConnectionType connectionType,
             @JsonProperty("ip_address") String ipAddress

--- a/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
@@ -36,7 +36,10 @@ public class ConnectionTypeResponse extends AbstractResponse {
     private final ConnectionType connectionType;
     private final String ipAddress;
 
-    public ConnectionTypeResponse(@JsonProperty("connection_type") ConnectionType connectionType, @JsonProperty("ip_address") String ipAddress) {
+    public ConnectionTypeResponse(
+            @JsonProperty("connection_type") ConnectionType connectionType,
+            @JsonProperty("ip_address") String ipAddress
+    ) {
         this.connectionType = connectionType;
         this.ipAddress = ipAddress;
     }

--- a/src/main/java/com/maxmind/geoip2/model/CountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/CountryResponse.java
@@ -12,6 +12,10 @@ import com.maxmind.geoip2.record.*;
  */
 public final class CountryResponse extends AbstractCountryResponse {
 
+    CountryResponse() {
+        this(null, null, null, null, null, null);
+    }
+
     public CountryResponse(
             @JsonProperty("continent") Continent continent,
             @JsonProperty("country") Country country,

--- a/src/main/java/com/maxmind/geoip2/model/CountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/CountryResponse.java
@@ -12,11 +12,14 @@ import com.maxmind.geoip2.record.*;
  */
 public final class CountryResponse extends AbstractCountryResponse {
 
-    public CountryResponse(@JsonProperty("continent") Continent continent, @JsonProperty("country") Country country,
-                        @JsonProperty("registered_country") Country registeredCountry,
-                        @JsonProperty("maxmind") MaxMind maxmind,
-                        @JsonProperty("represented_country") RepresentedCountry representedCountry,
-                        @JsonProperty("traits") Traits traits) {
-        super(continent, country, registeredCountry, maxmind, representedCountry, traits);
+    public CountryResponse(
+            @JsonProperty("continent") Continent continent,
+            @JsonProperty("country") Country country,
+            @JsonProperty("maxmind") MaxMind maxmind,
+            @JsonProperty("registered_country") Country registeredCountry,
+            @JsonProperty("represented_country") RepresentedCountry representedCountry,
+            @JsonProperty("traits") Traits traits
+    ) {
+        super(continent, country, maxmind, registeredCountry, representedCountry, traits);
     }
 }

--- a/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
@@ -10,6 +10,10 @@ public class DomainResponse extends AbstractResponse {
     private final String domain;
     private final String ipAddress;
 
+    DomainResponse() {
+        this(null, null);
+    }
+
     public DomainResponse(
             @JsonProperty("domain") String domain,
             @JsonProperty("ip_address") String ipAddress

--- a/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
@@ -10,7 +10,10 @@ public class DomainResponse extends AbstractResponse {
     private final String domain;
     private final String ipAddress;
 
-    public DomainResponse(@JsonProperty("domain") String domain, @JsonProperty("ip_address") String ipAddress) {
+    public DomainResponse(
+            @JsonProperty("domain") String domain,
+            @JsonProperty("ip_address") String ipAddress
+    ) {
         this.domain = domain;
         this.ipAddress = ipAddress;
     }

--- a/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
@@ -38,15 +38,4 @@ public class DomainResponse extends AbstractResponse {
     public String getIpAddress() {
         return this.ipAddress;
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "DomainResponse [domain=" + this.domain + ", ipAddress="
-                + this.ipAddress + "]";
-    }
 }

--- a/src/main/java/com/maxmind/geoip2/model/InsightsResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/InsightsResponse.java
@@ -21,6 +21,10 @@ import java.util.List;
  */
 public class InsightsResponse extends AbstractCityResponse {
 
+    InsightsResponse() {
+        this(null, null, null, null, null, null, null, null, null, null);
+    }
+
     public InsightsResponse(
             @JsonProperty("city") City city,
             @JsonProperty("continent") Continent continent,

--- a/src/main/java/com/maxmind/geoip2/model/InsightsResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/InsightsResponse.java
@@ -21,13 +21,19 @@ import java.util.List;
  */
 public class InsightsResponse extends AbstractCityResponse {
 
-    public InsightsResponse(@JsonProperty("maxmind") MaxMind maxmind, @JsonProperty("registered_country") Country registeredCountry,
-                            @JsonProperty("traits") Traits traits, @JsonProperty("country") Country country,
-                            @JsonProperty("continent") Continent continent, @JsonProperty("location") Location location,
-                            @JsonProperty("subdivisions") List<Subdivision> subdivisions,
-                            @JsonProperty("represented_country") RepresentedCountry representedCountry,
-                            @JsonProperty("postal") Postal postal, @JsonProperty("city") City city) {
-        super(maxmind, registeredCountry, traits, country, continent, location, subdivisions, representedCountry, postal, city);
+    public InsightsResponse(
+            @JsonProperty("city") City city,
+            @JsonProperty("continent") Continent continent,
+            @JsonProperty("country") Country country,
+            @JsonProperty("location") Location location,
+            @JsonProperty("maxmind") MaxMind maxmind,
+            @JsonProperty("postal") Postal postal,
+            @JsonProperty("registered_country") Country registeredCountry,
+            @JsonProperty("represented_country") RepresentedCountry representedCountry,
+            @JsonProperty("subdivisions") List<Subdivision> subdivisions,
+            @JsonProperty("traits") Traits traits
+    ) {
+        super(city, continent, country, location, maxmind, postal, registeredCountry,
+                representedCountry, subdivisions, traits);
     }
-
 }

--- a/src/main/java/com/maxmind/geoip2/model/IspResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/IspResponse.java
@@ -69,19 +69,4 @@ public class IspResponse extends AbstractResponse {
     public String getIpAddress() {
         return this.ipAddress;
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "IspResponse [autonomousSystemNumber="
-                + this.autonomousSystemNumber
-                + ", autonomousSystemOrganization="
-                + this.autonomousSystemOrganization + ", isp=" + this.isp
-                + ", organization=" + this.organization + ", ipAddress="
-                + this.ipAddress + "]";
-    }
 }

--- a/src/main/java/com/maxmind/geoip2/model/IspResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/IspResponse.java
@@ -13,6 +13,10 @@ public class IspResponse extends AbstractResponse {
     private final String organization;
     private final String ipAddress;
 
+    IspResponse() {
+        this(null, null, null, null, null);
+    }
+
     public IspResponse(
             @JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
             @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,

--- a/src/main/java/com/maxmind/geoip2/model/IspResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/IspResponse.java
@@ -13,10 +13,13 @@ public class IspResponse extends AbstractResponse {
     private final String organization;
     private final String ipAddress;
 
-    public IspResponse(@JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
-                       @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,
-                       @JsonProperty("isp") String isp, @JsonProperty("organization") String organization,
-                       @JsonProperty("ip_address") String ipAddress) {
+    public IspResponse(
+            @JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
+            @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,
+            @JsonProperty("ip_address") String ipAddress,
+            @JsonProperty("isp") String isp,
+            @JsonProperty("organization") String organization
+    ) {
         this.autonomousSystemNumber = autonomousSystemNumber;
         this.autonomousSystemOrganization = autonomousSystemOrganization;
         this.isp = isp;

--- a/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
@@ -11,7 +11,7 @@ import java.util.Map;
 /**
  * Abstract class for records with name maps.
  */
-public abstract class AbstractNamedRecord {
+public abstract class AbstractNamedRecord extends AbstractRecord {
 
     private final Map<String, String> names;
     private final Integer geoNameId;
@@ -58,15 +58,5 @@ public abstract class AbstractNamedRecord {
     @JsonProperty("names")
     public Map<String, String> getNames() {
         return new HashMap<String, String>(this.names);
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("AbstractNamedRecord{");
-        sb.append("locales=").append(locales);
-        sb.append(", names=").append(names);
-        sb.append(", geoNameId=").append(geoNameId);
-        sb.append('}');
-        return sb.toString();
     }
 }

--- a/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
@@ -1,5 +1,6 @@
 package com.maxmind.geoip2.record;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -36,6 +37,7 @@ public abstract class AbstractNamedRecord {
      * {@link com.maxmind.geoip2.WebServiceClient} constructor. This
      * attribute is returned by all end points.
      */
+    @JsonIgnore
     public String getName() {
         for (String lang : this.locales) {
             if (this.names.containsKey(lang)) {

--- a/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
@@ -17,7 +17,11 @@ public abstract class AbstractNamedRecord {
     private final Integer geoNameId;
     private final List<String> locales;
 
-    AbstractNamedRecord( Integer geoNameId, List<String> locales, Map<String, String> names) {
+    AbstractNamedRecord() {
+        this(null, null, null);
+    }
+
+    AbstractNamedRecord(List<String> locales, Integer geoNameId, Map<String, String> names) {
         this.names = names != null ? names : new HashMap<String, String>();
         this.geoNameId = geoNameId;
         this.locales = locales != null ? locales : new ArrayList<String>();

--- a/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
@@ -60,13 +60,13 @@ public abstract class AbstractNamedRecord {
         return new HashMap<String, String>(this.names);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
-        return this.getName() != null ? this.getName() : "";
+        final StringBuilder sb = new StringBuilder("AbstractNamedRecord{");
+        sb.append("locales=").append(locales);
+        sb.append(", names=").append(names);
+        sb.append(", geoNameId=").append(geoNameId);
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
@@ -17,7 +17,7 @@ public abstract class AbstractNamedRecord {
     private final Integer geoNameId;
     private final List<String> locales;
 
-    AbstractNamedRecord(Map<String, String> names, Integer geoNameId, List<String> locales) {
+    AbstractNamedRecord( Integer geoNameId, List<String> locales, Map<String, String> names) {
         this.names = names != null ? names : new HashMap<String, String>();
         this.geoNameId = geoNameId;
         this.locales = locales != null ? locales : new ArrayList<String>();

--- a/src/main/java/com/maxmind/geoip2/record/AbstractRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractRecord.java
@@ -1,11 +1,12 @@
 package com.maxmind.geoip2.record;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
-public class AbstractRecord {
+public abstract class AbstractRecord {
 
     /**
      * @return JSON representation of this object. The structure is the same as
@@ -16,6 +17,7 @@ public class AbstractRecord {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         return mapper.writeValueAsString(this);
     }
 

--- a/src/main/java/com/maxmind/geoip2/record/AbstractRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractRecord.java
@@ -1,11 +1,11 @@
-package com.maxmind.geoip2.model;
+package com.maxmind.geoip2.record;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
-public abstract class AbstractResponse {
+public class AbstractRecord {
 
     /**
      * @return JSON representation of this object. The structure is the same as
@@ -14,8 +14,8 @@ public abstract class AbstractResponse {
      */
     public String toJson() throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        mapper.setSerializationInclusion(Include.NON_EMPTY);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         return mapper.writeValueAsString(this);
     }
 

--- a/src/main/java/com/maxmind/geoip2/record/City.java
+++ b/src/main/java/com/maxmind/geoip2/record/City.java
@@ -22,9 +22,13 @@ public final class City extends AbstractNamedRecord {
         this(null, null, null, null);
     }
 
-    public City(@JsonProperty("names") Map<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
-                @JacksonInject("locales") List<String> locales, @JsonProperty("confidence") Integer confidence) {
-        super(names, geoNameId, locales);
+    public City(
+            @JacksonInject("locales") List<String> locales,
+            @JsonProperty("confidence") Integer confidence,
+            @JsonProperty("geoname_id") Integer geoNameId,
+            @JsonProperty("names") Map<String, String> names
+    ) {
+        super(geoNameId, locales, names);
         this.confidence = confidence;
     }
 

--- a/src/main/java/com/maxmind/geoip2/record/City.java
+++ b/src/main/java/com/maxmind/geoip2/record/City.java
@@ -40,6 +40,4 @@ public final class City extends AbstractNamedRecord {
     public Integer getConfidence() {
         return this.confidence;
     }
-
-
 }

--- a/src/main/java/com/maxmind/geoip2/record/City.java
+++ b/src/main/java/com/maxmind/geoip2/record/City.java
@@ -28,7 +28,7 @@ public final class City extends AbstractNamedRecord {
             @JsonProperty("geoname_id") Integer geoNameId,
             @JsonProperty("names") Map<String, String> names
     ) {
-        super(geoNameId, locales, names);
+        super(locales, geoNameId, names);
         this.confidence = confidence;
     }
 

--- a/src/main/java/com/maxmind/geoip2/record/Continent.java
+++ b/src/main/java/com/maxmind/geoip2/record/Continent.java
@@ -28,7 +28,7 @@ public final class Continent extends AbstractNamedRecord {
             @JsonProperty("geoname_id") Integer geoNameId,
             @JsonProperty("names") Map<String, String> names
     ) {
-        super(geoNameId, locales, names);
+        super(locales, geoNameId, names);
         this.code = code;
     }
 

--- a/src/main/java/com/maxmind/geoip2/record/Continent.java
+++ b/src/main/java/com/maxmind/geoip2/record/Continent.java
@@ -22,9 +22,13 @@ public final class Continent extends AbstractNamedRecord {
         this(null, null, null, null);
     }
 
-    public Continent(@JsonProperty("names") Map<String, String> names, @JsonProperty("code") String code,
-                     @JsonProperty("geoname_id") Integer geoNameId, @JacksonInject("locales") List<String> locales) {
-        super(names, geoNameId, locales);
+    public Continent(
+            @JacksonInject("locales") List<String> locales,
+            @JsonProperty("code") String code,
+            @JsonProperty("geoname_id") Integer geoNameId,
+            @JsonProperty("names") Map<String, String> names
+    ) {
+        super(geoNameId, locales, names);
         this.code = code;
     }
 

--- a/src/main/java/com/maxmind/geoip2/record/Country.java
+++ b/src/main/java/com/maxmind/geoip2/record/Country.java
@@ -23,9 +23,14 @@ public class Country extends AbstractNamedRecord {
         this(null, null, null, null, null);
     }
 
-    public Country(@JsonProperty("names") Map<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
-                   @JsonProperty("iso_code") String isoCode, @JsonProperty("confidence") Integer confidence, @JacksonInject("locales") List<String> locales) {
-        super(names, geoNameId, locales);
+    public Country(
+            @JacksonInject("locales") List<String> locales,
+            @JsonProperty("confidence") Integer confidence,
+            @JsonProperty("geoname_id") Integer geoNameId,
+            @JsonProperty("iso_code") String isoCode,
+            @JsonProperty("names") Map<String, String> names
+    ) {
+        super(geoNameId, locales, names);
         this.confidence = confidence;
         this.isoCode = isoCode;
     }

--- a/src/main/java/com/maxmind/geoip2/record/Country.java
+++ b/src/main/java/com/maxmind/geoip2/record/Country.java
@@ -30,7 +30,7 @@ public class Country extends AbstractNamedRecord {
             @JsonProperty("iso_code") String isoCode,
             @JsonProperty("names") Map<String, String> names
     ) {
-        super(geoNameId, locales, names);
+        super(locales, geoNameId, names);
         this.confidence = confidence;
         this.isoCode = isoCode;
     }

--- a/src/main/java/com/maxmind/geoip2/record/Location.java
+++ b/src/main/java/com/maxmind/geoip2/record/Location.java
@@ -111,24 +111,17 @@ public class Location {
         return this.longitude;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
-        return "Location ["
-                + (this.accuracyRadius != null ? "accuracyRadius="
-                + this.accuracyRadius + ", " : "")
-                + (this.latitude != null ? "latitude=" + this.latitude + ", "
-                : "")
-                + (this.longitude != null ? "longitude=" + this.longitude
-                + ", " : "")
-                + (this.metroCode != null ? "metroCode=" + this.metroCode
-                + ", " : "")
-                + (this.timeZone != null ? "timeZone=" + this.timeZone : "")
-                + "]";
+        final StringBuilder sb = new StringBuilder("Location{");
+        sb.append("accuracyRadius=").append(accuracyRadius);
+        sb.append(", averageIncome=").append(averageIncome);
+        sb.append(", latitude=").append(latitude);
+        sb.append(", longitude=").append(longitude);
+        sb.append(", metroCode=").append(metroCode);
+        sb.append(", populationDensity=").append(populationDensity);
+        sb.append(", timeZone='").append(timeZone).append('\'');
+        sb.append('}');
+        return sb.toString();
     }
-
 }

--- a/src/main/java/com/maxmind/geoip2/record/Location.java
+++ b/src/main/java/com/maxmind/geoip2/record/Location.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * This record is returned by all the end points except the Country end point.
  * </p>
  */
-public class Location {
+public class Location extends AbstractRecord  {
 
     private final Integer accuracyRadius;
     private final Integer averageIncome;
@@ -109,19 +109,5 @@ public class Location {
      */
     public Double getLongitude() {
         return this.longitude;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("Location{");
-        sb.append("accuracyRadius=").append(accuracyRadius);
-        sb.append(", averageIncome=").append(averageIncome);
-        sb.append(", latitude=").append(latitude);
-        sb.append(", longitude=").append(longitude);
-        sb.append(", metroCode=").append(metroCode);
-        sb.append(", populationDensity=").append(populationDensity);
-        sb.append(", timeZone='").append(timeZone).append('\'');
-        sb.append('}');
-        return sb.toString();
     }
 }

--- a/src/main/java/com/maxmind/geoip2/record/Location.java
+++ b/src/main/java/com/maxmind/geoip2/record/Location.java
@@ -24,10 +24,15 @@ public class Location {
         this(null, null, null, null, null, null, null);
     }
 
-    public Location(@JsonProperty("average_income") Integer averageIncome, @JsonProperty("population_density") Integer populationDensity,
-                    @JsonProperty("time_zone") String timeZone, @JsonProperty("accuracy_radius") Integer accuracyRadius,
-                    @JsonProperty("metro_code") Integer metroCode, @JsonProperty("latitude") Double latitude,
-                    @JsonProperty("longitude") Double longitude) {
+    public Location(
+            @JsonProperty("accuracy_radius") Integer accuracyRadius,
+            @JsonProperty("average_income") Integer averageIncome,
+            @JsonProperty("latitude") Double latitude,
+            @JsonProperty("longitude") Double longitude,
+            @JsonProperty("metro_code") Integer metroCode,
+            @JsonProperty("population_density") Integer populationDensity,
+            @JsonProperty("time_zone") String timeZone
+    ) {
         this.accuracyRadius = accuracyRadius;
         this.averageIncome = averageIncome;
         this.latitude = latitude;

--- a/src/main/java/com/maxmind/geoip2/record/MaxMind.java
+++ b/src/main/java/com/maxmind/geoip2/record/MaxMind.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * This record is returned by all the end points.
  * </p>
  */
-public final class MaxMind {
+public final class MaxMind extends AbstractRecord  {
 
     private final Integer queriesRemaining;
 
@@ -30,18 +30,4 @@ public final class MaxMind {
     public Integer getQueriesRemaining() {
         return this.queriesRemaining;
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "MaxMind ["
-                + (this.getQueriesRemaining() != null ? "getQueriesRemaining()="
-                + this.getQueriesRemaining()
-                : "") + "]";
-    }
-
 }

--- a/src/main/java/com/maxmind/geoip2/record/Postal.java
+++ b/src/main/java/com/maxmind/geoip2/record/Postal.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * This record is returned by all the end points except the Country end point.
  * </p>
  */
-public final class Postal {
+public final class Postal extends AbstractRecord  {
 
     private final String code;
     private final Integer confidence;
@@ -44,14 +44,5 @@ public final class Postal {
      */
     public Integer getConfidence() {
         return this.confidence;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("Postal{");
-        sb.append("code='").append(code).append('\'');
-        sb.append(", confidence=").append(confidence);
-        sb.append('}');
-        return sb.toString();
     }
 }

--- a/src/main/java/com/maxmind/geoip2/record/Postal.java
+++ b/src/main/java/com/maxmind/geoip2/record/Postal.java
@@ -46,14 +46,12 @@ public final class Postal {
         return this.confidence;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
-        return this.code != null ? this.code : "";
+        final StringBuilder sb = new StringBuilder("Postal{");
+        sb.append("code='").append(code).append('\'');
+        sb.append(", confidence=").append(confidence);
+        sb.append('}');
+        return sb.toString();
     }
-
 }

--- a/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
+++ b/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
@@ -24,10 +24,15 @@ public final class RepresentedCountry extends Country {
         this(null, null, null, null, null, null);
     }
 
-    public RepresentedCountry(@JsonProperty("names") Map<String, String> names, @JsonProperty("geoname_id") Integer geoNameId,
-                              @JacksonInject("locales") List<String> locales, @JsonProperty("confidence") Integer confidence,
-                              @JsonProperty("iso_code") String isoCode, @JsonProperty("type") String type) {
-        super(names, geoNameId, isoCode, confidence, locales);
+    public RepresentedCountry(
+            @JacksonInject("locales") List<String> locales,
+            @JsonProperty("confidence") Integer confidence,
+            @JsonProperty("geoname_id") Integer geoNameId,
+            @JsonProperty("iso_code") String isoCode,
+            @JsonProperty("names") Map<String, String> names,
+            @JsonProperty("type") String type
+    ) {
+        super(locales, confidence, geoNameId, isoCode, names);
         this.type = type;
     }
 

--- a/src/main/java/com/maxmind/geoip2/record/Subdivision.java
+++ b/src/main/java/com/maxmind/geoip2/record/Subdivision.java
@@ -29,7 +29,7 @@ public final class Subdivision extends AbstractNamedRecord {
             @JsonProperty("iso_code") String isoCode,
             @JsonProperty("names") Map<String, String> names
     ) {
-        super(geoNameId, locales, names);
+        super(locales, geoNameId, names);
         this.confidence = confidence;
         this.isoCode = isoCode;
     }

--- a/src/main/java/com/maxmind/geoip2/record/Subdivision.java
+++ b/src/main/java/com/maxmind/geoip2/record/Subdivision.java
@@ -3,7 +3,8 @@ package com.maxmind.geoip2.record;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>

--- a/src/main/java/com/maxmind/geoip2/record/Subdivision.java
+++ b/src/main/java/com/maxmind/geoip2/record/Subdivision.java
@@ -19,13 +19,17 @@ public final class Subdivision extends AbstractNamedRecord {
     private final String isoCode;
 
     public Subdivision() {
-        this(null, null, null, new HashMap<String, String>(), new ArrayList<String>());
+        this(null, null, null, null, null);
     }
 
-    public Subdivision(@JsonProperty("confidence") Integer confidence, @JsonProperty("iso_code") String isoCode,
-                       @JsonProperty("geoname_id") Integer geoNameId, @JsonProperty("names") Map<String, String> names,
-                       @JacksonInject("locales") List<String> locales) {
-        super(names, geoNameId, locales);
+    public Subdivision(
+            @JacksonInject("locales") List<String> locales,
+            @JsonProperty("confidence") Integer confidence,
+            @JsonProperty("geoname_id") Integer geoNameId,
+            @JsonProperty("iso_code") String isoCode,
+            @JsonProperty("names") Map<String, String> names
+    ) {
+        super(geoNameId, locales, names);
         this.confidence = confidence;
         this.isoCode = isoCode;
     }

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -53,7 +53,6 @@ public final class Traits {
      * returned by all end points.
      * @see <a href="http://dev.maxmind.com/faq/geoip#anonproxy">MaxMind's GeoIP
      * FAQ</a>
-     *
      * @deprecated Use our
      * <a href="https://www.maxmind.com/en/geoip2-anonymous-ip-database">GeoIP2
      * Anonymous IP database</a> instead.
@@ -102,7 +101,6 @@ public final class Traits {
     /**
      * @return This is true if the IP belong to a satellite internet provider.
      * This attribute is returned by all end points.
-     *
      * @deprecated Due to increased mobile usage, we have insufficient data to
      * maintain this field.
      */

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * This record is returned by all the end points.
  * </p>
  */
-public final class Traits {
+public final class Traits extends AbstractRecord  {
 
     private final Integer autonomousSystemNumber;
     private final String autonomousSystemOrganization;
@@ -173,34 +173,4 @@ public final class Traits {
     public String getDomain() {
         return this.domain;
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
-    @Override
-    public String toString() {
-        return "Traits ["
-                + (this.autonomousSystemNumber != null ? "autonomousSystemNumber="
-                + this.autonomousSystemNumber + ", "
-                : "")
-                + (this.autonomousSystemOrganization != null ? "autonomousSystemOrganization="
-                + this.autonomousSystemOrganization + ", "
-                : "")
-                + (this.domain != null ? "domain=" + this.domain + ", " : "")
-                + (this.ipAddress != null ? "ipAddress=" + this.ipAddress
-                + ", " : "")
-                + "anonymousProxy="
-                + this.anonymousProxy
-                + ", satelliteProvider="
-                + this.satelliteProvider
-                + ", "
-                + (this.isp != null ? "isp=" + this.isp + ", " : "")
-                + (this.organization != null ? "organization="
-                + this.organization + ", " : "")
-                + (this.userType != null ? "userType=" + this.userType : "")
-                + "]";
-    }
-
 }

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -23,17 +23,20 @@ public final class Traits {
     private final String userType;
 
     public Traits() {
-        this(false, null, null, null, false, null, null, null, null);
+        this(null, null, null, null, false, false, null, null, null);
     }
 
-    public Traits(@JsonProperty("is_anonymous_proxy") boolean anonymousProxy,
-                  @JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
-                  @JsonProperty("isp") String isp, @JsonProperty("ip_address") String ipAddress,
-                  @JsonProperty("is_satellite_provider") boolean satelliteProvider,
-                  @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,
-                  @JsonProperty("user_type") String userType,
-                  @JsonProperty("organization") String organization,
-                  @JsonProperty("domain") String domain) {
+    public Traits(
+            @JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
+            @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,
+            @JsonProperty("domain") String domain,
+            @JsonProperty("ip_address") String ipAddress,
+            @JsonProperty("is_anonymous_proxy") boolean anonymousProxy,
+            @JsonProperty("is_satellite_provider") boolean satelliteProvider,
+            @JsonProperty("isp") String isp,
+            @JsonProperty("organization") String organization,
+            @JsonProperty("user_type") String userType
+    ) {
         this.autonomousSystemNumber = autonomousSystemNumber;
         this.autonomousSystemOrganization = autonomousSystemOrganization;
         this.domain = domain;

--- a/src/test/java/com/maxmind/geoip2/CountryTest.java
+++ b/src/test/java/com/maxmind/geoip2/CountryTest.java
@@ -1,16 +1,15 @@
 package com.maxmind.geoip2;
 
-import static org.junit.Assert.assertEquals;
+import com.google.api.client.http.HttpTransport;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CountryResponse;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.net.InetAddress;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import com.google.api.client.http.HttpTransport;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.CountryResponse;
+import static org.junit.Assert.assertEquals;
 
 public class CountryTest {
     private CountryResponse country;

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -235,7 +235,7 @@ public class DatabaseReaderTest {
         reader.close();
     }
 
-    File getFile(String filename) throws URISyntaxException {
+    private File getFile(String filename) throws URISyntaxException {
         URL resource = DatabaseReaderTest.class
                 .getResource("/maxmind-db/test-data/" + filename);
         return new File(resource.toURI());

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -1,9 +1,14 @@
 package com.maxmind.geoip2;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.maxmind.db.Reader;
+import com.maxmind.geoip2.exception.AddressNotFoundException;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.*;
+import com.maxmind.geoip2.model.ConnectionTypeResponse.ConnectionType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,16 +18,8 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 
-import com.maxmind.geoip2.model.*;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import com.maxmind.db.Reader;
-import com.maxmind.geoip2.exception.AddressNotFoundException;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.ConnectionTypeResponse.ConnectionType;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.*;
 
 public class DatabaseReaderTest {
 

--- a/src/test/java/com/maxmind/geoip2/ExceptionTest.java
+++ b/src/test/java/com/maxmind/geoip2/ExceptionTest.java
@@ -1,18 +1,16 @@
 package com.maxmind.geoip2;
 
-import static org.hamcrest.CoreMatchers.containsString;
-
-import java.io.IOException;
-import java.net.InetAddress;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import com.google.api.client.http.HttpTransport;
 import com.maxmind.geoip2.exception.*;
 import com.maxmind.geoip2.matchers.CodeMatcher;
 import com.maxmind.geoip2.matchers.HttpStatusMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.net.InetAddress;
+
+import static org.hamcrest.CoreMatchers.containsString;
 
 public class ExceptionTest {
 

--- a/src/test/java/com/maxmind/geoip2/HostTest.java
+++ b/src/test/java/com/maxmind/geoip2/HostTest.java
@@ -1,15 +1,12 @@
 package com.maxmind.geoip2;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.net.InetAddress;
-
+import com.google.api.client.http.HttpTransport;
+import com.maxmind.geoip2.model.InsightsResponse;
 import org.junit.Test;
 
-import com.google.api.client.http.HttpTransport;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.InsightsResponse;
+import java.net.InetAddress;
+
+import static org.junit.Assert.assertEquals;
 
 public class HostTest {
 

--- a/src/test/java/com/maxmind/geoip2/InsightsTest.java
+++ b/src/test/java/com/maxmind/geoip2/InsightsTest.java
@@ -1,16 +1,15 @@
 package com.maxmind.geoip2;
 
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import com.google.api.client.http.HttpTransport;
 import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.InsightsResponse;
 import com.maxmind.geoip2.record.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.List;
 
 import static org.junit.Assert.*;
 
@@ -51,8 +50,8 @@ public class InsightsTest {
 
     @Test
     public void leastSpecificSubdivision() {
-    	assertEquals("Most specific subdivision returns first subdivision",
-    		"MN", this.insights.getLeastSpecificSubdivision().getIsoCode());
+        assertEquals("Most specific subdivision returns first subdivision",
+                "MN", this.insights.getLeastSpecificSubdivision().getIsoCode());
     }
 
     @SuppressWarnings("boxing")

--- a/src/test/java/com/maxmind/geoip2/MeTest.java
+++ b/src/test/java/com/maxmind/geoip2/MeTest.java
@@ -1,14 +1,10 @@
 package com.maxmind.geoip2;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-
+import com.google.api.client.http.HttpTransport;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.api.client.http.HttpTransport;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
+import static org.junit.Assert.assertEquals;
 
 public class MeTest {
     private WebServiceClient client;

--- a/src/test/java/com/maxmind/geoip2/NamesTest.java
+++ b/src/test/java/com/maxmind/geoip2/NamesTest.java
@@ -1,19 +1,14 @@
 package com.maxmind.geoip2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import com.google.api.client.http.HttpTransport;
+import com.maxmind.geoip2.model.CityResponse;
+import org.junit.Test;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.Test;
-
-import com.google.api.client.http.HttpTransport;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.CityResponse;
+import static org.junit.Assert.*;
 
 public class NamesTest {
     private final HttpTransport transport = new TestTransport();

--- a/src/test/java/com/maxmind/geoip2/NullTest.java
+++ b/src/test/java/com/maxmind/geoip2/NullTest.java
@@ -3,6 +3,7 @@ package com.maxmind.geoip2;
 import com.google.api.client.http.HttpTransport;
 import com.maxmind.geoip2.model.InsightsResponse;
 import com.maxmind.geoip2.record.*;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -22,7 +23,7 @@ public class NullTest {
         InsightsResponse insights = this.client.insights(InetAddress
                 .getByName("1.2.3.13"));
 
-        assertTrue(insights.toString().startsWith("Insights"));
+        assertThat(insights.toString(), CoreMatchers.startsWith("{"));
 
         City city = insights.getCity();
         assertNotNull(city);
@@ -42,7 +43,7 @@ public class NullTest {
         assertNull(location.getLongitude());
         assertNull(location.getMetroCode());
         assertNull(location.getTimeZone());
-        assertEquals("Location []", location.toString());
+        assertThat(location.toString(), CoreMatchers.startsWith("{"));
 
         MaxMind maxmind = insights.getMaxMind();
         assertNotNull(maxmind);
@@ -84,7 +85,7 @@ public class NullTest {
         assertFalse(traits.isAnonymousProxy());
         assertFalse(traits.isSatelliteProvider());
         assertEquals(
-                "Traits [anonymousProxy=false, satelliteProvider=false, ]",
+                "{\"is_anonymous_proxy\":false,\"is_satellite_provider\":false}",
                 traits.toString());
 
         for (Country c : new Country[]{country, registeredCountry,
@@ -99,7 +100,7 @@ public class NullTest {
             assertNull(r.getGeoNameId());
             assertNull(r.getName());
             assertTrue(r.getNames().isEmpty());
-            assertEquals("", r.toString());
+            assertEquals("{}", r.toString());
         }
     }
 }

--- a/src/test/java/com/maxmind/geoip2/NullTest.java
+++ b/src/test/java/com/maxmind/geoip2/NullTest.java
@@ -1,21 +1,14 @@
 package com.maxmind.geoip2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import com.google.api.client.http.HttpTransport;
+import com.maxmind.geoip2.model.InsightsResponse;
+import com.maxmind.geoip2.record.*;
+import org.junit.Test;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.util.List;
 
-import org.junit.Test;
-
-import com.google.api.client.http.HttpTransport;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.InsightsResponse;
-import com.maxmind.geoip2.record.*;
+import static org.junit.Assert.*;
 
 public class NullTest {
 

--- a/src/test/java/com/maxmind/geoip2/TestTransport.java
+++ b/src/test/java/com/maxmind/geoip2/TestTransport.java
@@ -160,12 +160,11 @@ public final class TestTransport extends MockHttpTransport {
         "}";
 
     @Override
-    public LowLevelHttpRequest buildRequest(String method, final String url)
-            throws IOException {
+    public LowLevelHttpRequest buildRequest(String method, final String url) {
         return new MockLowLevelHttpRequest() {
 
             @Override
-            public LowLevelHttpResponse execute() throws IOException {
+            public LowLevelHttpResponse execute() {
                 String path = url.replaceFirst(
                         "https://geoip.maxmind.com/geoip/v2.1/", "");
                 // only 1.7 supports switching on strings

--- a/src/test/java/com/maxmind/geoip2/matchers/CodeMatcher.java
+++ b/src/test/java/com/maxmind/geoip2/matchers/CodeMatcher.java
@@ -1,9 +1,8 @@
 package com.maxmind.geoip2.matchers;
 
+import com.maxmind.geoip2.exception.InvalidRequestException;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-
-import com.maxmind.geoip2.exception.InvalidRequestException;
 
 public class CodeMatcher extends TypeSafeMatcher<InvalidRequestException> {
 

--- a/src/test/java/com/maxmind/geoip2/matchers/HttpStatusMatcher.java
+++ b/src/test/java/com/maxmind/geoip2/matchers/HttpStatusMatcher.java
@@ -1,9 +1,8 @@
 package com.maxmind.geoip2.matchers;
 
+import com.maxmind.geoip2.exception.HttpException;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-
-import com.maxmind.geoip2.exception.HttpException;
 
 public class HttpStatusMatcher extends TypeSafeMatcher<HttpException> {
 

--- a/src/test/java/com/maxmind/geoip2/model/JsonTest.java
+++ b/src/test/java/com/maxmind/geoip2/model/JsonTest.java
@@ -2,6 +2,7 @@ package com.maxmind.geoip2.model;
 
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jr.ob.JSON;
 import org.junit.Test;
@@ -293,6 +294,7 @@ public class JsonTest {
             (Class<T> cls, String json)
             throws IOException {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         InjectableValues inject = new InjectableValues.Std().addValue(
                 "locales", Collections.singletonList("en"));
         T response = mapper.reader(cls).with(inject).readValue(json);

--- a/src/test/java/com/maxmind/geoip2/model/JsonTest.java
+++ b/src/test/java/com/maxmind/geoip2/model/JsonTest.java
@@ -1,112 +1,304 @@
 package com.maxmind.geoip2.model;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.util.ArrayList;
-
-import org.junit.Test;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jr.ob.JSON;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
 
 public class JsonTest {
 
-    private String insightsBody = " {\n"
-            + "    \"maxmind\" : {\n"
-            + "       \"queries_remaining\" : 11\n"
-            + "    },\n"
-            + "    \"registered_country\" : {\n"
-            + "       \"geoname_id\" : 2,\n"
-            + "       \"names\" : {\n"
-            + "          \"en\" : \"Canada\"\n"
-            + "       },\n"
-            + "       \"iso_code\" : \"CA\"\n"
-            + "    },\n"
-            + "    \"traits\" : {\n"
-            + "       \"is_anonymous_proxy\" : true,\n"
-            + "       \"autonomous_system_number\" : 1234,\n"
-            + "       \"isp\" : \"Comcast\",\n"
-            + "       \"ip_address\" : \"1.2.3.4\",\n"
-            + "       \"is_satellite_provider\" : true,\n"
-            + "       \"autonomous_system_organization\" : \"AS Organization\",\n"
-            + "       \"user_type\" : \"college\",\n"
-            + "       \"organization\" : \"Blorg\",\n"
-            + "       \"domain\" : \"example.com\"\n"
-            + "    },\n"
-            + "    \"country\" : {\n"
-            + "       \"names\" : {\n"
-            + "          \"en\" : \"United States of America\"\n"
-            + "       },\n"
-            + "       \"geoname_id\" : 1,\n"
-            + "       \"iso_code\" : \"US\",\n"
-            + "       \"confidence\" : 99\n"
-            + "    },\n"
-            + "    \"continent\" : {\n"
-            + "       \"names\" : {\n"
-            + "          \"en\" : \"North America\"\n"
-            + "       },\n"
-            + "       \"code\" : \"NA\",\n"
-            + "       \"geoname_id\" : 42\n"
-            + "    },\n"
-            + "    \"location\" : {\n"
-            + "       \"average_income\" : 24626,\n"
-            + "       \"population_density\" : 1341,\n"
-            + "       \"time_zone\" : \"America/Chicago\",\n"
-            + "       \"accuracy_radius\" : 1500,\n"
-            + "       \"metro_code\" : 765,\n"
-            + "       \"latitude\" : 44.98,\n"
-            + "       \"longitude\" : 93.2636\n"
-            + "    },\n"
-            + "    \"subdivisions\" : [\n"
-            + "       {\n"
-            + "          \"confidence\" : 88,\n"
-            + "          \"iso_code\" : \"MN\",\n"
-            + "          \"geoname_id\" : 574635,\n"
-            + "          \"names\" : {\n"
-            + "             \"en\" : \"Minnesota\"\n"
-            + "          }\n"
-            + "       },\n"
-            + "       {\n"
-            + "          \"iso_code\" : \"TT\"\n"
-            + "       }\n"
-            + "    ],\n"
-            + "    \"represented_country\" : {\n"
-            + "       \"geoname_id\" : 3,\n"
-            + "       \"names\" : {\n"
-            + "          \"en\" : \"United Kingdom\"\n"
-            + "       },\n"
-            + "       \"type\" : \"C<military>\",\n"
-            + "       \"iso_code\" : \"GB\"\n"
-            + "    },\n"
-            + "    \"postal\" : {\n"
-            + "       \"code\" : \"55401\",\n"
-            + "       \"confidence\" : 33\n"
-            + "    },\n"
-            + "    \"city\" : {\n"
-            + "       \"confidence\" : 76,\n"
-            + "       \"geoname_id\" : 9876,\n"
-            + "       \"names\" : {\n"
-            + "          \"en\" : \"Minneapolis\"\n"
-            + "       }\n"
-            + "    }\n"
-            + " }\n";
+    @Test
+    public void testInsightsSerialization() throws IOException {
+        String json = JSON.std
+                .composeString()
+                .startObject()
+                .startObjectField("maxmind")
+                .put("queries_remaining", 11)
+                .end()
+                .startObjectField("registered_country")
+                .put("geoname_id", 2)
+                .startObjectField("names")
+                .put("en", "Canada")
+                .end()
+                .put("iso_code", "CA")
+                .end()
+                .startObjectField("traits")
+                .put("is_anonymous_proxy", true)
+                .put("autonomous_system_number", 1234)
+                .put("isp", "Comcast")
+                .put("ip_address", "1.2.3.4")
+                .put("is_satellite_provider", true)
+                .put("autonomous_system_organization", "AS Organization")
+                .put("user_type", "college")
+                .put("organization", "Blorg")
+                .put("domain", "example.com")
+                .end()
+                .startObjectField("country")
+                .startObjectField("names")
+                .put("en", "United States of America")
+                .end()
+                .put("geoname_id", 1)
+                .put("iso_code", "US")
+                .put("confidence", 99)
+                .end()
+                .startObjectField("continent")
+                .startObjectField("names")
+                .put("en", "North America")
+                .end()
+                .put("code", "NA")
+                .put("geoname_id", 42)
+                .end()
+                .startObjectField("location")
+                .put("average_income", 24626)
+                .put("population_density", 1341)
+                .put("time_zone", "America/Chicago")
+                .put("accuracy_radius", 1500)
+                .put("metro_code", 765)
+                .put("latitude", 44.98)
+                .put("longitude", 93.2636)
+                .end()
+                .startArrayField("subdivisions")
+                .startObject()
+                .put("confidence", 88)
+                .put("iso_code", "MN")
+                .put("geoname_id", 574635)
+                .startObjectField("names")
+                .put("en", "Minnesota")
+                .end()
+                .end()
+                .startObject()
+                .put("iso_code", "TT")
+                .end()
+                .end()
+                .startObjectField("represented_country")
+                .put("geoname_id", 3)
+                .startObjectField("names")
+                .put("en", "United Kingdom")
+                .end()
+                .put("type", "C<military>")
+                .put("iso_code", "GB")
+                .end()
+                .startObjectField("postal")
+                .put("code", "55401")
+                .put("confidence", 33)
+                .end()
+                .startObjectField("city")
+                .put("confidence", 76)
+                .put("geoname_id", 9876)
+                .startObjectField("names")
+                .put("en", "Minneapolis")
+                .end()
+                .end()
+                .end()
+                .finish();
+
+        testRoundTrip(InsightsResponse.class, json);
+    }
 
     @Test
-    public void testSerialization() throws IOException {
+    public void testCitySerialization() throws IOException {
+        String json = JSON.std
+                .composeString()
+                .startObject()
+                .startObjectField("maxmind")
+                .put("queries_remaining", 11)
+                .end()
+                .startObjectField("registered_country")
+                .put("geoname_id", 2)
+                .startObjectField("names")
+                .put("en", "Canada")
+                .end()
+                .put("iso_code", "CA")
+                .end()
+                .startObjectField("traits")
+                .put("is_anonymous_proxy", true)
+                .put("autonomous_system_number", 1234)
+                .put("isp", "Comcast")
+                .put("ip_address", "1.2.3.4")
+                .put("is_satellite_provider", true)
+                .put("autonomous_system_organization", "AS Organization")
+                .put("organization", "Blorg")
+                .put("domain", "example.com")
+                .end()
+                .startObjectField("country")
+                .startObjectField("names")
+                .put("en", "United States of America")
+                .end()
+                .put("geoname_id", 1)
+                .put("iso_code", "US")
+                .end()
+                .startObjectField("continent")
+                .startObjectField("names")
+                .put("en", "North America")
+                .end()
+                .put("code", "NA")
+                .put("geoname_id", 42)
+                .end()
+                .startObjectField("location")
+                .put("time_zone", "America/Chicago")
+                .put("metro_code", 765)
+                .put("latitude", 44.98)
+                .put("longitude", 93.2636)
+                .end()
+                .startArrayField("subdivisions")
+                .startObject()
+                .put("iso_code", "MN")
+                .put("geoname_id", 574635)
+                .startObjectField("names")
+                .put("en", "Minnesota")
+                .end()
+                .end()
+                .startObject()
+                .put("iso_code", "TT")
+                .end()
+                .end()
+                .startObjectField("represented_country")
+                .put("geoname_id", 3)
+                .startObjectField("names")
+                .put("en", "United Kingdom")
+                .end()
+                .put("type", "C<military>")
+                .put("iso_code", "GB")
+                .end()
+                .startObjectField("postal")
+                .put("code", "55401")
+                .end()
+                .startObjectField("city")
+                .put("geoname_id", 9876)
+                .startObjectField("names")
+                .put("en", "Minneapolis")
+                .end()
+                .end()
+                .end()
+                .finish();
+
+        testRoundTrip(CityResponse.class, json);
+    }
+
+    @Test
+    public void testCountrySerialization() throws IOException {
+        String json = JSON.std
+                .composeString()
+                .startObject()
+                .startObjectField("maxmind")
+                .put("queries_remaining", 11)
+                .end()
+                .startObjectField("registered_country")
+                .put("geoname_id", 2)
+                .startObjectField("names")
+                .put("en", "Canada")
+                .end()
+                .put("iso_code", "CA")
+                .end()
+                .startObjectField("traits")
+                .put("is_anonymous_proxy", true)
+                .put("ip_address", "1.2.3.4")
+                .put("is_satellite_provider", true)
+                .end()
+                .startObjectField("country")
+                .startObjectField("names")
+                .put("en", "United States of America")
+                .end()
+                .put("geoname_id", 1)
+                .put("iso_code", "US")
+                .end()
+                .startObjectField("continent")
+                .startObjectField("names")
+                .put("en", "North America")
+                .end()
+                .put("code", "NA")
+                .put("geoname_id", 42)
+                .end()
+                .startObjectField("represented_country")
+                .put("geoname_id", 3)
+                .startObjectField("names")
+                .put("en", "United Kingdom")
+                .end()
+                .put("type", "C<military>")
+                .put("iso_code", "GB")
+                .end()
+                .end()
+                .finish();
+
+        testRoundTrip(CountryResponse.class, json);
+    }
+
+    @Test
+    public void testAnonymousIPSerialization() throws Exception {
+        String json = JSON.std
+                .composeString()
+                .startObject()
+                .put("is_anonymous", true)
+                .put("is_anonymous_vpn", true)
+                .put("is_hosting_provider", true)
+                .put("is_public_proxy", true)
+                .put("is_tor_exit_node", true)
+                .put("ip_address", "1.1.1.1")
+                .end()
+                .finish();
+
+        testRoundTrip(AnonymousIpResponse.class, json);
+    }
+
+    @Test
+    public void testConnectionTypeSerialization() throws Exception {
+        String json = JSON.std
+                .composeString()
+                .startObject()
+                .put("connection_type", "Dialup")
+                .put("ip_address", "1.1.1.1")
+                .end()
+                .finish();
+
+        testRoundTrip(ConnectionTypeResponse.class, json);
+    }
+
+    @Test
+    public void testDomainSerialization() throws Exception {
+        String json = JSON.std
+                .composeString()
+                .startObject()
+                .put("domain", "gmail.com")
+                .put("ip_address", "1.1.1.1")
+                .end()
+                .finish();
+
+        testRoundTrip(DomainResponse.class, json);
+    }
+
+
+    @Test
+    public void testIspSerialization() throws Exception {
+        String json = JSON.std
+                .composeString()
+                .startObject()
+                .put("autonomous_system_number", 2121)
+                .put("autonomous_system_organization", "Google, Inc.")
+                .put("isp", "ISP, Inc.")
+                .put("organization", "Google, Inc.")
+                .put("ip_address", "1.1.1.1")
+                .end()
+                .finish();
+
+        testRoundTrip(IspResponse.class, json);
+    }
+
+    protected <T extends AbstractResponse> void testRoundTrip
+            (Class<T> cls, String json)
+            throws IOException {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                false);
         InjectableValues inject = new InjectableValues.Std().addValue(
-                "locales", new ArrayList<String>());
-        InsightsResponse response = mapper.reader(InsightsResponse.class)
-                .with(inject).readValue(this.insightsBody);
-        JsonNode expectedNode = mapper.readValue(this.insightsBody,
-                JsonNode.class);
-        JsonNode actualNode = mapper.readValue(response.toJson(),
-                JsonNode.class);
+                "locales", Collections.singletonList("en"));
+        T response = mapper.reader(cls).with(inject).readValue(json);
+
+        JsonNode expectedNode = mapper.readValue(json, JsonNode.class);
+        JsonNode actualNode = mapper.readValue(response.toJson(), JsonNode.class);
 
         assertEquals(expectedNode, actualNode);
     }


### PR DESCRIPTION
This adds tests for serialization of all the response classes. I also reorganized the constructor params added in #52 to be less random and updated some `toString()` methods that were missing fields.