### PR TITLE
Create and/or inject http transport at client build time

### DIFF
--- a/src/test/java/com/maxmind/geoip2/CountryTest.java
+++ b/src/test/java/com/maxmind/geoip2/CountryTest.java
@@ -18,7 +18,7 @@ public class CountryTest {
     public void setUp() throws IOException, GeoIp2Exception {
         HttpTransport transport = new TestTransport();
         WebServiceClient client = new WebServiceClient.Builder(42,
-                "abcdef123456").testTransport(transport).build();
+                "abcdef123456").httpTransport(transport).build();
 
         this.country = client.country(InetAddress.getByName("1.1.1.3"));
     }

--- a/src/test/java/com/maxmind/geoip2/ExceptionTest.java
+++ b/src/test/java/com/maxmind/geoip2/ExceptionTest.java
@@ -17,7 +17,7 @@ public class ExceptionTest {
     private final HttpTransport transport = new TestTransport();
 
     private final WebServiceClient client = new WebServiceClient.Builder(42,
-            "abcdef123456").testTransport(this.transport).build();
+            "abcdef123456").httpTransport(this.transport).build();
 
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/src/test/java/com/maxmind/geoip2/HostTest.java
+++ b/src/test/java/com/maxmind/geoip2/HostTest.java
@@ -14,7 +14,7 @@ public class HostTest {
     public void insights() throws Exception {
         HttpTransport transport = new TestTransport();
         WebServiceClient client = new WebServiceClient.Builder(42,
-                "abcdef123456").host("blah.com").testTransport(transport)
+                "abcdef123456").host("blah.com").httpTransport(transport)
                 .build();
 
         InsightsResponse insights = client.insights(InetAddress

--- a/src/test/java/com/maxmind/geoip2/InsightsTest.java
+++ b/src/test/java/com/maxmind/geoip2/InsightsTest.java
@@ -21,7 +21,7 @@ public class InsightsTest {
         HttpTransport transport = new TestTransport();
 
         WebServiceClient client = new WebServiceClient.Builder(42, "012345689")
-                .testTransport(transport).build();
+                .httpTransport(transport).build();
 
         this.insights = client.insights(InetAddress.getByName("1.1.1.1"));
     }

--- a/src/test/java/com/maxmind/geoip2/MeTest.java
+++ b/src/test/java/com/maxmind/geoip2/MeTest.java
@@ -14,7 +14,7 @@ public class MeTest {
         HttpTransport transport = new TestTransport();
 
         this.client = new WebServiceClient.Builder(42, "abcdef123456")
-                .testTransport(transport).build();
+                .httpTransport(transport).build();
 
     }
 

--- a/src/test/java/com/maxmind/geoip2/NamesTest.java
+++ b/src/test/java/com/maxmind/geoip2/NamesTest.java
@@ -16,7 +16,7 @@ public class NamesTest {
     @Test
     public void testNames() throws Exception {
         WebServiceClient client = new WebServiceClient.Builder(42,
-                "abcdef123456").testTransport(this.transport)
+                "abcdef123456").httpTransport(this.transport)
                 .locales(Arrays.asList("zh-CN", "ru")).build();
 
         CityResponse city = client.city(InetAddress.getByName("1.1.1.2"));
@@ -31,7 +31,7 @@ public class NamesTest {
     @Test
     public void russianFallback() throws Exception {
         WebServiceClient client = new WebServiceClient.Builder(42,
-                "abcdef123456").testTransport(this.transport)
+                "abcdef123456").httpTransport(this.transport)
                 .locales(Arrays.asList("as", "ru")).build();
 
         CityResponse city = client.city(InetAddress.getByName("1.1.1.2"));
@@ -44,7 +44,7 @@ public class NamesTest {
     @Test
     public void testFallback() throws Exception {
         WebServiceClient client = new WebServiceClient.Builder(42,
-                "abcdef123456").testTransport(this.transport)
+                "abcdef123456").httpTransport(this.transport)
                 .locales(Arrays.asList("pt", "en", "zh-CN")).build();
         CityResponse city = client.city(InetAddress.getByName("1.1.1.2"));
         assertEquals("en is returned when pt is missing", "North America", city.getContinent()
@@ -55,7 +55,7 @@ public class NamesTest {
     @Test
     public void noFallback() throws Exception {
         WebServiceClient client = new WebServiceClient.Builder(42,
-                "abcdef123456").testTransport(this.transport)
+                "abcdef123456").httpTransport(this.transport)
                 .locales(Arrays.asList("pt", "es", "af")).build();
         CityResponse city = client.city(InetAddress.getByName("1.1.1.2"));
 
@@ -66,7 +66,7 @@ public class NamesTest {
     @Test
     public void noLocale() throws Exception {
         WebServiceClient client = new WebServiceClient.Builder(42,
-                "abcdef123456").testTransport(this.transport).build();
+                "abcdef123456").httpTransport(this.transport).build();
         CityResponse city = client.city(InetAddress.getByName("1.1.1.2"));
         assertEquals("en is returned when no locales are specified", "North America", city
                 .getContinent().getName());
@@ -76,7 +76,7 @@ public class NamesTest {
     @Test
     public void testMissing() throws Exception {
         WebServiceClient client = new WebServiceClient.Builder(42,
-                "abcdef123456").testTransport(this.transport)
+                "abcdef123456").httpTransport(this.transport)
                 .locales(Collections.singletonList("en")).build();
 
         CityResponse city = client.city(InetAddress.getByName("1.1.1.2"));

--- a/src/test/java/com/maxmind/geoip2/NullTest.java
+++ b/src/test/java/com/maxmind/geoip2/NullTest.java
@@ -16,7 +16,7 @@ public class NullTest {
     private final HttpTransport transport = new TestTransport();
 
     private final WebServiceClient client = new WebServiceClient.Builder(42,
-            "abcdef123456").testTransport(this.transport).build();
+            "abcdef123456").httpTransport(this.transport).build();
 
     @Test
     public void testDefaults() throws Exception {


### PR DESCRIPTION
Fixes issue #70. Also useful for developers who want to use the more configurable Apache HTTP client transport provided by the google-http-client rather than the default `NetHttpTransport`.