### PR TITLE
Added support for library to handle database file updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.2</version>
         </dependency>
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-compress</artifactId>
+		    <version>1.13</version>
+		</dependency>       
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
@@ -1,22 +1,27 @@
 package com.maxmind.geoip2;
 
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.*;
-
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 
-public interface DatabaseProvider extends GeoIp2Provider {
+import com.maxmind.db.Metadata;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.AnonymousIpResponse;
+import com.maxmind.geoip2.model.ConnectionTypeResponse;
+import com.maxmind.geoip2.model.DomainResponse;
+import com.maxmind.geoip2.model.EnterpriseResponse;
+import com.maxmind.geoip2.model.IspResponse;
+
+public interface DatabaseProvider extends GeoIp2Provider, Closeable {
     /**
      * Look up an IP address in a GeoIP2 Anonymous IP.
      *
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a AnonymousIpResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException                          if there is an IO error
+     * @throws java.io.IOException if there is an IO error
      */
-    AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception;
+    AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException, GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 Connection Type database.
@@ -24,10 +29,9 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a ConnectTypeResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException                          if there is an IO error
+     * @throws java.io.IOException if there is an IO error
      */
-    ConnectionTypeResponse connectionType(InetAddress ipAddress)
-            throws IOException, GeoIp2Exception;
+    ConnectionTypeResponse connectionType(InetAddress ipAddress) throws IOException, GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 Domain database.
@@ -35,10 +39,9 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a DomainResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException                          if there is an IO error
+     * @throws java.io.IOException if there is an IO error
      */
-    DomainResponse domain(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception;
+    DomainResponse domain(InetAddress ipAddress) throws IOException, GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 Enterprise database.
@@ -46,10 +49,9 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return an EnterpriseResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException                          if there is an IO error
+     * @throws java.io.IOException if there is an IO error
      */
-    EnterpriseResponse enterprise(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception;
+    EnterpriseResponse enterprise(InetAddress ipAddress) throws IOException, GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 ISP database.
@@ -57,8 +59,13 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return an IspResponse for the requested IP address.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
-     * @throws java.io.IOException                          if there is an IO error
+     * @throws java.io.IOException if there is an IO error
      */
-    IspResponse isp(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception;
+    IspResponse isp(InetAddress ipAddress) throws IOException, GeoIp2Exception;
+
+    /**
+     * @return the metadata for the open MaxMind DB file.
+     * @throws IOException
+     */
+    Metadata getMetadata() throws IOException;
 }

--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -1,14 +1,5 @@
 package com.maxmind.geoip2;
 
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.maxmind.db.*;
-import com.maxmind.db.Reader.FileMode;
-import com.maxmind.geoip2.exception.AddressNotFoundException;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.*;
-
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -16,46 +7,60 @@ import java.net.InetAddress;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.maxmind.db.InvalidDatabaseException;
+import com.maxmind.db.Metadata;
+import com.maxmind.db.NoCache;
+import com.maxmind.db.NodeCache;
+import com.maxmind.db.Reader;
+import com.maxmind.db.Reader.FileMode;
+import com.maxmind.geoip2.exception.AddressNotFoundException;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.AnonymousIpResponse;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.model.ConnectionTypeResponse;
+import com.maxmind.geoip2.model.CountryResponse;
+import com.maxmind.geoip2.model.DomainResponse;
+import com.maxmind.geoip2.model.EnterpriseResponse;
+import com.maxmind.geoip2.model.IspResponse;
+
 /**
- * Instances of this class provide a reader for the GeoIP2 database format. IP
- * addresses can be looked up using the {@code get} method.
+ * Instances of this class provide a reader for the GeoIP2 database format. IP addresses can be looked up using the {@code get}
+ * method.
  */
-public class DatabaseReader implements DatabaseProvider, Closeable {
-
+public class DatabaseReader implements DatabaseProvider {
     private final Reader reader;
-
     private final ObjectMapper om;
-
     private final List<String> locales;
 
-    private DatabaseReader(Builder builder) throws IOException {
+    DatabaseReader(Builder builder) throws IOException {
         if (builder.stream != null) {
-            this.reader = new Reader(builder.stream, builder.cache);
+            reader = new Reader(builder.stream, builder.cache);
         } else if (builder.database != null) {
-            this.reader = new Reader(builder.database, builder.mode, builder.cache);
+            reader = new Reader(builder.database, builder.mode, builder.cache);
         } else {
             // This should never happen. If it does, review the Builder class
             // constructors for errors.
-            throw new IllegalArgumentException(
-                    "Unsupported Builder configuration: expected either File or URL");
+            throw new IllegalArgumentException("Unsupported Builder configuration: expected either File or URL");
         }
-        this.om = new ObjectMapper();
-        this.om.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
-        this.om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-                false);
-        this.om.configure(
-                DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
-        this.locales = builder.locales;
+        om = new ObjectMapper();
+        om.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
+        om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        om.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+        locales = builder.locales;
     }
 
     /**
      * <p>
-     * Constructs a Builder for the DatabaseReader. The file passed to it must
-     * be a valid GeoIP2 database file.
+     * Constructs a Builder for the DatabaseReader. The file passed to it must be a valid GeoIP2 database file.
      * </p>
      * <p>
-     * {@code Builder} creates instances of {@code DatabaseReader}
-     * from values set by the methods.
+     * {@code Builder} creates instances of {@code DatabaseReader} from values set by the methods.
      * </p>
      * <p>
      * Only the values set in the {@code Builder} constructor are required.
@@ -68,13 +73,15 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
         List<String> locales = Collections.singletonList("en");
         FileMode mode = FileMode.MEMORY_MAPPED;
         NodeCache cache = NoCache.getInstance();
+        boolean lazyInitialise;
+        boolean reload;
 
         /**
          * @param stream the stream containing the GeoIP2 database to use.
          */
         public Builder(InputStream stream) {
             this.stream = stream;
-            this.database = null;
+            database = null;
         }
 
         /**
@@ -82,16 +89,15 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
          */
         public Builder(File database) {
             this.database = database;
-            this.stream = null;
+            stream = null;
         }
 
         /**
-         * @param val List of locale codes to use in name property from most
-         *            preferred to least preferred.
+         * @param val List of locale codes to use in name property from most preferred to least preferred.
          * @return Builder object
          */
         public Builder locales(List<String> val) {
-            this.locales = val;
+            locales = val;
             return this;
         }
 
@@ -107,25 +113,50 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
         /**
          * @param val The file mode used to open the GeoIP2 database
          * @return Builder object
-         * @throws java.lang.IllegalArgumentException if you initialized the Builder with a URL, which uses
-         *                                            {@link FileMode#MEMORY}, but you provided a different
-         *                                            FileMode to this method.
+         * @throws java.lang.IllegalArgumentException if you initialized the Builder with a URL, which uses {@link FileMode#MEMORY},
+         *         but you provided a different FileMode to this method.
          */
         public Builder fileMode(FileMode val) {
-            if (this.stream != null && FileMode.MEMORY != val) {
-                throw new IllegalArgumentException(
-                        "Only FileMode.MEMORY is supported when using an InputStream.");
+            if (stream != null && FileMode.MEMORY != val) {
+                throw new IllegalArgumentException("Only FileMode.MEMORY is supported when using an InputStream.");
             }
-            this.mode = val;
+            mode = val;
             return this;
         }
 
         /**
-         * @return an instance of {@code DatabaseReader} created from the
-         * fields set on this builder.
+         * Enables the ability for this reader to be reloaded when updates are available.
+         *
+         * @return Builder object
+         */
+        public Builder withReload() {
+            return withReload(false);
+        }
+
+        /**
+         * Enables the ability for this reader to be reloaded when updates are available. Lazy initialisation can also be enabled,
+         * allowing a client to start an application with no database file whilst this can be downloading in another thread.
+         *
+         * @param lazyInitialise
+         * @return Builder object
+         */
+        public Builder withReload(boolean lazyInitialise) {
+            if (database == null) {
+                throw new IllegalArgumentException("Only File based mode is supported for reloading.");
+            }
+            reload = true;
+            this.lazyInitialise = lazyInitialise;
+            return this;
+        }
+
+        /**
+         * @return an instance of {@code DatabaseProvider} created from the fields set on this builder.
          * @throws IOException if there is an error reading the database
          */
-        public DatabaseReader build() throws IOException {
+        public DatabaseProvider build() throws IOException {
+            if (reload) {
+                return new ReloadableDatabaseProvider(this, database, lazyInitialise);
+            }
             return new DatabaseReader(this);
         }
     }
@@ -133,19 +164,16 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
     /**
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return A <T> object with the data for the IP address
-     * @throws IOException              if there is an error opening or reading from the file.
+     * @throws IOException if there is an error opening or reading from the file.
      * @throws AddressNotFoundException if the IP address is not in our database
      */
-    private <T> T get(InetAddress ipAddress, Class<T> cls,
-                      String type) throws IOException, AddressNotFoundException {
+    private <T> T get(InetAddress ipAddress, Class<T> cls, String type) throws IOException, AddressNotFoundException {
 
-        String databaseType = this.getMetadata().getDatabaseType();
+        String databaseType = getMetadata().getDatabaseType();
         if (!databaseType.contains(type)) {
-            String caller = Thread.currentThread().getStackTrace()[2]
-                    .getMethodName();
+            String caller = Thread.currentThread().getStackTrace()[2].getMethodName();
             throw new UnsupportedOperationException(
-                    "Invalid attempt to open a " + databaseType
-                            + " database using the " + caller + " method");
+                            "Invalid attempt to open a " + databaseType + " database using the " + caller + " method");
         }
 
         ObjectNode node = jsonNodeToObjectNode(reader.get(ipAddress));
@@ -153,22 +181,19 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
         // We throw the same exception as the web service when an IP is not in
         // the database
         if (node == null) {
-            throw new AddressNotFoundException("The address "
-                    + ipAddress.getHostAddress() + " is not in the database.");
+            throw new AddressNotFoundException("The address " + ipAddress.getHostAddress() + " is not in the database.");
         }
 
         InjectableValues inject = new JsonInjector(locales, ipAddress.getHostAddress());
 
-        return this.om.reader(inject).treeToValue(node, cls);
+        return om.reader(inject).treeToValue(node, cls);
     }
 
-    private ObjectNode jsonNodeToObjectNode(JsonNode node)
-            throws InvalidDatabaseException {
+    private ObjectNode jsonNodeToObjectNode(JsonNode node) throws InvalidDatabaseException {
         if (node == null || node instanceof ObjectNode) {
             return (ObjectNode) node;
         }
-        throw new InvalidDatabaseException(
-                "Unexpected data type returned. The GeoIP2 database may be corrupt.");
+        throw new InvalidDatabaseException("Unexpected data type returned. The GeoIP2 database may be corrupt.");
     }
 
     /**
@@ -176,29 +201,25 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
      * Closes the database.
      * </p>
      * <p>
-     * If you are using {@code FileMode.MEMORY_MAPPED}, this will
-     * <em>not</em> unmap the underlying file due to a limitation in Java's
-     * {@code MappedByteBuffer}. It will however set the reference to
-     * the buffer to {@code null}, allowing the garbage collector to
-     * collect it.
+     * If you are using {@code FileMode.MEMORY_MAPPED}, this will <em>not</em> unmap the underlying file due to a limitation in
+     * Java's {@code MappedByteBuffer}. It will however set the reference to the buffer to {@code null}, allowing the garbage
+     * collector to collect it.
      * </p>
      *
      * @throws IOException if an I/O error occurs.
      */
     @Override
     public void close() throws IOException {
-        this.reader.close();
+        reader.close();
     }
 
     @Override
-    public CountryResponse country(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception {
+    public CountryResponse country(InetAddress ipAddress) throws IOException, GeoIp2Exception {
         return this.get(ipAddress, CountryResponse.class, "Country");
     }
 
     @Override
-    public CityResponse city(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception {
+    public CityResponse city(InetAddress ipAddress) throws IOException, GeoIp2Exception {
         return this.get(ipAddress, CityResponse.class, "City");
     }
 
@@ -208,11 +229,10 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a AnonymousIpResponse for the requested IP address.
      * @throws GeoIp2Exception if there is an error looking up the IP
-     * @throws IOException     if there is an IO error
+     * @throws IOException if there is an IO error
      */
     @Override
-    public AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception {
+    public AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException, GeoIp2Exception {
         return this.get(ipAddress, AnonymousIpResponse.class, "GeoIP2-Anonymous-IP");
     }
 
@@ -222,13 +242,11 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a ConnectTypeResponse for the requested IP address.
      * @throws GeoIp2Exception if there is an error looking up the IP
-     * @throws IOException     if there is an IO error
+     * @throws IOException if there is an IO error
      */
     @Override
-    public ConnectionTypeResponse connectionType(InetAddress ipAddress)
-            throws IOException, GeoIp2Exception {
-        return this.get(ipAddress, ConnectionTypeResponse.class,
-                "GeoIP2-Connection-Type");
+    public ConnectionTypeResponse connectionType(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return this.get(ipAddress, ConnectionTypeResponse.class, "GeoIP2-Connection-Type");
     }
 
     /**
@@ -237,13 +255,11 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return a DomainResponse for the requested IP address.
      * @throws GeoIp2Exception if there is an error looking up the IP
-     * @throws IOException     if there is an IO error
+     * @throws IOException if there is an IO error
      */
     @Override
-    public DomainResponse domain(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception {
-        return this
-                .get(ipAddress, DomainResponse.class, "GeoIP2-Domain");
+    public DomainResponse domain(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return this.get(ipAddress, DomainResponse.class, "GeoIP2-Domain");
     }
 
     /**
@@ -252,14 +268,12 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return an EnterpriseResponse for the requested IP address.
      * @throws GeoIp2Exception if there is an error looking up the IP
-     * @throws IOException     if there is an IO error
+     * @throws IOException if there is an IO error
      */
     @Override
-    public EnterpriseResponse enterprise(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception {
+    public EnterpriseResponse enterprise(InetAddress ipAddress) throws IOException, GeoIp2Exception {
         return this.get(ipAddress, EnterpriseResponse.class, "Enterprise");
     }
-
 
     /**
      * Look up an IP address in a GeoIP2 ISP database.
@@ -267,18 +281,18 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
      * @param ipAddress IPv4 or IPv6 address to lookup.
      * @return an IspResponse for the requested IP address.
      * @throws GeoIp2Exception if there is an error looking up the IP
-     * @throws IOException     if there is an IO error
+     * @throws IOException if there is an IO error
      */
     @Override
-    public IspResponse isp(InetAddress ipAddress) throws IOException,
-            GeoIp2Exception {
+    public IspResponse isp(InetAddress ipAddress) throws IOException, GeoIp2Exception {
         return this.get(ipAddress, IspResponse.class, "GeoIP2-ISP");
     }
 
     /**
      * @return the metadata for the open MaxMind DB file.
      */
+    @Override
     public Metadata getMetadata() {
-        return this.reader.getMetadata();
+        return reader.getMetadata();
     }
 }

--- a/src/main/java/com/maxmind/geoip2/ReloadableDatabaseProvider.java
+++ b/src/main/java/com/maxmind/geoip2/ReloadableDatabaseProvider.java
@@ -1,0 +1,172 @@
+/* HEADER */
+package com.maxmind.geoip2;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.maxmind.db.Metadata;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.AnonymousIpResponse;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.model.ConnectionTypeResponse;
+import com.maxmind.geoip2.model.CountryResponse;
+import com.maxmind.geoip2.model.DomainResponse;
+import com.maxmind.geoip2.model.EnterpriseResponse;
+import com.maxmind.geoip2.model.IspResponse;
+
+/**
+ * Implementation of {@link DatabaseProvider} that allows the {@link DatabaseReader} to be rebuilt when the database is updated.
+ */
+public class ReloadableDatabaseProvider implements DatabaseProvider {
+    private final ReentrantLock lock = new ReentrantLock();
+    private final DatabaseReader.Builder builder;
+    private final Callable<Boolean> availableChecker;
+    private DatabaseProvider databaseProvider;
+
+    /**
+     * Construct a {@link ReloadableDatabaseProvider} which initialises its reader eagerly.
+     *
+     * @param builder
+     * @param databaseFile
+     * @throws IOException
+     */
+    public ReloadableDatabaseProvider(DatabaseReader.Builder builder, File databaseFile) throws IOException {
+        this(builder, new DatabaseFileAvailableChecker(databaseFile), false);
+    }
+
+    /**
+     * Construct a {@link ReloadableDatabaseProvider}. This constructor provides a lazy initialization option, that allows a client
+     * to start an application with no database file whilst this can be downloaded in another thread.
+     *
+     * @param builder
+     * @param databaseFile
+     * @param lazyInitialization
+     * @throws IOException
+     */
+    public ReloadableDatabaseProvider(DatabaseReader.Builder builder, File databaseFile, boolean lazyInitialization)
+        throws IOException {
+        this(builder, new DatabaseFileAvailableChecker(databaseFile), true);
+    }
+
+    /**
+     * Construct a {@link ReloadableDatabaseProvider}. This constructor provides options to check if the database is available and
+     * also lazy initialisation. Lazy initialisation allows a client to start an application with no database file whilst this can
+     * be downloaded in another thread.
+     *
+     * @param builder
+     * @param availableChecker
+     * @param lazyInitialization
+     * @throws IOException
+     */
+    public ReloadableDatabaseProvider(DatabaseReader.Builder builder, Callable<Boolean> availableChecker,
+                                      boolean lazyInitialization)
+        throws IOException {
+        this.builder = builder;
+        this.availableChecker = availableChecker;
+
+        if (!lazyInitialization) {
+            initialise();
+        }
+    }
+
+    @Override
+    public CountryResponse country(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return getProvider().country(ipAddress);
+    }
+
+    @Override
+    public CityResponse city(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return getProvider().city(ipAddress);
+    }
+
+    @Override
+    public AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return getProvider().anonymousIp(ipAddress);
+    }
+
+    @Override
+    public ConnectionTypeResponse connectionType(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return getProvider().connectionType(ipAddress);
+    }
+
+    @Override
+    public DomainResponse domain(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return getProvider().domain(ipAddress);
+    }
+
+    @Override
+    public EnterpriseResponse enterprise(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return getProvider().enterprise(ipAddress);
+    }
+
+    @Override
+    public IspResponse isp(InetAddress ipAddress) throws IOException, GeoIp2Exception {
+        return getProvider().isp(ipAddress);
+    }
+
+    private DatabaseProvider getProvider() throws IOException {
+        initialise();
+        return databaseProvider;
+    }
+
+    private void initialise() throws IOException {
+        try {
+            boolean tryLock = lock.tryLock(500L, TimeUnit.MILLISECONDS);
+            if (tryLock && availableChecker.call()) {
+                close();
+                databaseProvider = new DatabaseReader(builder);
+            }
+
+            if (databaseProvider == null) {
+                throw new IOException("Reader has not been constructed, database not available!");
+            }
+        } catch (Exception expt) {
+            throw new IOException("Unable to initialise database!", expt);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public Metadata getMetadata() throws IOException {
+        return getProvider().getMetadata();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (databaseProvider != null) {
+            databaseProvider.close();
+        }
+    }
+
+    /**
+     * Implementation of {@link Callable} that returns <tt>true</tt> if the supplied database {@link File} exists or has been
+     * modified.
+     */
+    public static class DatabaseFileAvailableChecker implements Callable<Boolean> {
+        private final File database;
+        private Long lastModified;
+
+        public DatabaseFileAvailableChecker(File database) {
+            this.database = database;
+        }
+
+        @Override
+        public Boolean call() throws Exception {
+            if (!database.exists()) {
+                return false;
+            }
+
+            long updatedLastModified = database.lastModified();
+            if (lastModified != null && lastModified.equals(updatedLastModified)) {
+                return false;
+            }
+            lastModified = database.lastModified();
+            return true;
+        }
+    }
+}

--- a/src/main/java/com/maxmind/geoip2/download/DatabaseDownloader.java
+++ b/src/main/java/com/maxmind/geoip2/download/DatabaseDownloader.java
@@ -1,0 +1,244 @@
+/* HEADER */
+package com.maxmind.geoip2.download;
+
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.commons.compress.utils.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+
+import com.maxmind.geoip2.exception.HttpException;
+
+/**
+ * {@code Downloader} responsible for downloading the currently available database and it's related checksum.
+ */
+public class DatabaseDownloader implements Closeable {
+    static final String DATABASE_FILE_SUFFIX = "tar.gz";
+    static final String DATABASE_MD5_SUFFIX = "tar.gz.md5";
+
+    private final String host;
+    private final String editionId;
+    private final String licenseKey;
+    private final boolean useHttps;
+    private final int port;
+    private final CloseableHttpClient httpClient;
+
+    public DatabaseDownloader(Builder builder) {
+        host = builder.host;
+        port = builder.port;
+        useHttps = builder.useHttps;
+        editionId = builder.editionId;
+        licenseKey = builder.licenseKey;
+
+        RequestConfig.Builder configBuilder = RequestConfig.custom().setConnectTimeout(builder.connectTimeout)
+                        .setSocketTimeout(builder.readTimeout);
+
+        if (builder.proxy != null) {
+            InetSocketAddress address = (InetSocketAddress) builder.proxy.address();
+            HttpHost proxyHost = new HttpHost(address.getHostName(), address.getPort());
+            configBuilder.setProxy(proxyHost);
+        }
+
+        RequestConfig config = configBuilder.build();
+        httpClient = HttpClientBuilder.create().setUserAgent(userAgent()).setDefaultRequestConfig(config).build();
+    }
+
+    private String userAgent() {
+        return "GeoIP2/" + getClass().getPackage().getImplementationVersion() + " (Java/" + System.getProperty("java.version")
+                        + ")";
+    }
+
+    /**
+     * Returns the checksum of the currently available database.
+     *
+     * @return
+     * @throws IOException
+     */
+    public String getDatabaseMd5() throws IOException {
+        return responseFor(DATABASE_MD5_SUFFIX, new ResponseHandler<String>() {
+            @Override
+            public String handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
+                return EntityUtils.toString(response.getEntity(), "UTF-8");
+            }
+        });
+    }
+
+    /**
+     * Returns the currently available database.
+     *
+     * @param file
+     * @return
+     * @throws IOException
+     */
+    public void downloadDatabaseToFile(final File file) throws IOException {
+        responseFor(DATABASE_FILE_SUFFIX, new ResponseHandler<Void>() {
+            @Override
+            public Void handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
+                InputStream source = response.getEntity().getContent();
+                try (OutputStream output = new BufferedOutputStream(new FileOutputStream(file))) {
+                    IOUtils.copy(source, output);
+                }
+                return null;
+            }
+        });
+    }
+
+    private <T> T responseFor(String suffix, ResponseHandler<T> handler) throws IOException {
+        try {
+            URL url = new URIBuilder().setScheme(useHttps ? "https" : "http").setHost(host).setPort(port)
+                            .setPath("/app/geoip_download").addParameter("edition_id", editionId).addParameter("suffix", suffix)
+                            .addParameter("license_key", licenseKey).build().toURL();
+            HttpGet request = new HttpGet(url.toURI());
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                return handleResponse(response, url, handler);
+            }
+        } catch (URISyntaxException use) {
+            throw new IOException("Error parsing request URL", use);
+        }
+    }
+
+    private <T> T handleResponse(CloseableHttpResponse response, URL url, ResponseHandler<T> handler) throws IOException {
+        int status = response.getStatusLine().getStatusCode();
+        if (status >= 400 && status < 600) {
+            throw new HttpException("Received a server error (" + status + ") for " + url, status, url);
+        } else if (status != 200) {
+            throw new HttpException("Received an unexpected HTTP status (" + status + ") for " + url, status, url);
+        }
+
+        try {
+            return handler.handleResponse(response);
+        } catch (IOException ioe) {
+            throw new IOException("Received a 200 response but could not decode ", ioe);
+        } finally {
+            HttpEntity entity = response.getEntity();
+            EntityUtils.consume(entity);
+        }
+    }
+
+    /**
+     * Close any open connections and return resources to the system.
+     */
+    @Override
+    public void close() throws IOException {
+        httpClient.close();
+    }
+
+    /**
+     * <p>
+     * {@code Builder} creates instances of {@code DatabaseDownloader} from values set by the methods.
+     * </p>
+     * <p>
+     * This example shows how to create a {@code DatabaseDownloader} object with the {@code Builder}:
+     * </p>
+     * <p>
+     * DatabaseDownloader client = new DatabaseDownloader.Builder("GeoIP2-City","licensekey").build();
+     * </p>
+     * <p>
+     * Only the values set in the {@code Builder} constructor are required.
+     * </p>
+     */
+    public static final class Builder {
+        private final String editionId;
+        private final String licenseKey;
+
+        private String host = "download.maxmind.com";
+        private int port = 443;
+        private boolean useHttps = true;
+
+        private int connectTimeout = 3000;
+        private int readTimeout = 20000;
+        private Proxy proxy;
+
+        /**
+         * @param editionId Your MaxMind edition ID.
+         * @param licenseKey Your MaxMind license key.
+         */
+        public Builder(String editionId, String licenseKey) {
+            this.editionId = editionId;
+            this.licenseKey = licenseKey;
+        }
+
+        /**
+         * @param val Timeout in milliseconds to establish a connection to the service. The default is 3000 (3 seconds).
+         * @return Builder object
+         */
+        public Builder connectTimeout(int val) {
+            connectTimeout = val;
+            return this;
+        }
+
+        /**
+         * Disables HTTPS to connect to a test server or proxy.
+         *
+         * @return Builder object
+         */
+        public Builder disableHttps() {
+            useHttps = false;
+            return this;
+        }
+
+        /**
+         * @param val The host to use.
+         * @return Builder object
+         */
+        public Builder host(String val) {
+            host = val;
+            return this;
+        }
+
+        /**
+         * @param val The port to use.
+         * @return Builder object
+         */
+        public Builder port(int val) {
+            port = val;
+            return this;
+        }
+
+        /**
+         * @param val readTimeout in milliseconds to read data from an established connection to the service. The default is 20000
+         *        (20 seconds).
+         * @return Builder object
+         */
+        public Builder readTimeout(int val) {
+            readTimeout = val;
+            return this;
+        }
+
+        /**
+         * @param val the proxy to use when making this request.
+         * @return Builder object
+         */
+        public Builder proxy(Proxy val) {
+            proxy = val;
+            return this;
+        }
+
+        /**
+         * @return an instance of {@code DatabaseDownloader} created from the fields set on this builder.
+         */
+        public DatabaseDownloader build() {
+            return new DatabaseDownloader(this);
+        }
+    }
+}

--- a/src/main/java/com/maxmind/geoip2/download/DatabaseUpdater.java
+++ b/src/main/java/com/maxmind/geoip2/download/DatabaseUpdater.java
@@ -1,0 +1,29 @@
+/* HEADER */
+package com.maxmind.geoip2.download;
+
+import java.io.IOException;
+
+/**
+ * Responsible for downloading updated versions of the database when they are created.
+ */
+public interface DatabaseUpdater {
+
+    /**
+     * Verifies the current available version and if a newer one exists, downloads it replacing the current version.
+     *
+     * @return
+     * @throws IOException
+     */
+    boolean refresh() throws IOException;
+
+    /**
+     * Implementation of {@link DatabaseUpdater} that always returns <tt>false</tt> to refresh requests.
+     */
+    class NoopDatabaseUpdater implements DatabaseUpdater {
+
+        @Override
+        public boolean refresh() {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/maxmind/geoip2/download/FileBasedDatabaseUpdater.java
+++ b/src/main/java/com/maxmind/geoip2/download/FileBasedDatabaseUpdater.java
@@ -1,0 +1,105 @@
+/* HEADER */
+package com.maxmind.geoip2.download;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.utils.IOUtils;
+
+/**
+ * Responsible for downloading updated versions of the database when they are created.
+ */
+public class FileBasedDatabaseUpdater {
+    private static final String DATABASE_FILE_EXTENSION = ".mmdb";
+    private static final String CHECKSUM_FILE_EXTENSION = ".checksum";
+
+    private final DatabaseDownloader downloader;
+    private final File database;
+    private String databaseMd5;
+
+    public FileBasedDatabaseUpdater(DatabaseDownloader downloader, File database) throws IOException {
+        this.downloader = downloader;
+        this.database = database;
+        databaseMd5 = readCheckSum();
+    }
+
+    private String readCheckSum() throws IOException {
+        Path checkSumPath = getCheckSumPath();
+        if (checkSumPath.toFile().exists()) {
+            byte[] readAllBytes = Files.readAllBytes(checkSumPath);
+            return new String(readAllBytes, "UTF-8");
+        }
+        return null;
+    }
+
+    private Path getCheckSumPath() {
+        return new File(database.getParent(), database.getName() + CHECKSUM_FILE_EXTENSION).toPath();
+    }
+
+    /**
+     * Verifies the current available version and if a newer one exists, downloads it replacing the current version.
+     *
+     * @return
+     * @throws IOException
+     */
+    public boolean refresh() throws IOException {
+        String databaseMd5 = downloader.getDatabaseMd5();
+        if (this.databaseMd5 == null || !this.databaseMd5.equals(databaseMd5)) {
+            replaceExistingDatabase();
+            writeCheckSum(databaseMd5);
+            this.databaseMd5 = databaseMd5;
+            return true;
+        }
+        return false;
+    }
+
+    private void replaceExistingDatabase() throws IOException {
+        File tmpTarFile = Files.createTempFile(database.getName() + "-", ".tar.gz").toFile();
+        downloader.downloadDatabaseToFile(tmpTarFile);
+
+        File replacementDatabase = new File(tmpTarFile.getParentFile(), database.getName() + DATABASE_FILE_EXTENSION);
+        extractAndOverwriteFile(replacementDatabase, tmpTarFile);
+        tmpTarFile.delete();
+
+        CopyOption[] copyOptions = { StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES };
+        Files.copy(replacementDatabase.toPath(), database.toPath(), copyOptions);
+        replacementDatabase.delete();
+    }
+
+    private static void extractAndOverwriteFile(File database, File tmpTarFile) throws IOException {
+        ArchiveInputStream tarInputStream = new TarArchiveInputStream(
+                        new GzipCompressorInputStream(new BufferedInputStream(new FileInputStream(tmpTarFile))));
+        try {
+            ArchiveEntry entry = null;
+            while ((entry = tarInputStream.getNextEntry()) != null) {
+                if (entry.getName().endsWith(DATABASE_FILE_EXTENSION)) {
+                    final OutputStream outputFileStream = new BufferedOutputStream(new FileOutputStream(database));
+                    IOUtils.copy(tarInputStream, outputFileStream);
+                    IOUtils.closeQuietly(outputFileStream);
+                    break;
+                }
+            }
+        } finally {
+            IOUtils.closeQuietly(tarInputStream);
+        }
+    }
+
+    private void writeCheckSum(String databaseMd5) throws IOException, UnsupportedEncodingException {
+        Path checkSumPath = getCheckSumPath();
+        Files.write(checkSumPath, databaseMd5.getBytes("UTF-8"));
+    }
+}

--- a/src/main/java/com/maxmind/geoip2/download/FileBasedDatabaseUpdater.java
+++ b/src/main/java/com/maxmind/geoip2/download/FileBasedDatabaseUpdater.java
@@ -21,7 +21,7 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.utils.IOUtils;
 
 /**
- * Responsible for downloading updated versions of the database when they are created.
+ * Concrete implementation of {@link DatabaseUpdater} that updates {@link File}s.
  */
 public class FileBasedDatabaseUpdater {
     private static final String DATABASE_FILE_EXTENSION = ".mmdb";

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -1,14 +1,9 @@
 package com.maxmind.geoip2;
 
-import com.maxmind.db.Reader;
-import com.maxmind.geoip2.exception.AddressNotFoundException;
-import com.maxmind.geoip2.exception.GeoIp2Exception;
-import com.maxmind.geoip2.model.*;
-import com.maxmind.geoip2.model.ConnectionTypeResponse.ConnectionType;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,8 +13,21 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import com.maxmind.db.Reader;
+import com.maxmind.geoip2.exception.AddressNotFoundException;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.AnonymousIpResponse;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.model.ConnectionTypeResponse;
+import com.maxmind.geoip2.model.ConnectionTypeResponse.ConnectionType;
+import com.maxmind.geoip2.model.DomainResponse;
+import com.maxmind.geoip2.model.EnterpriseResponse;
+import com.maxmind.geoip2.model.IspResponse;
 
 public class DatabaseReaderTest {
 
@@ -30,30 +38,26 @@ public class DatabaseReaderTest {
 
     @Before
     public void setup() throws URISyntaxException, IOException {
-        URL resource = DatabaseReaderTest.class
-                .getResource("/maxmind-db/test-data/GeoIP2-City-Test.mmdb");
-        this.geoipStream = resource.openStream();
-        this.geoipFile = new File(resource.toURI());
+        URL resource = DatabaseReaderTest.class.getResource("/maxmind-db/test-data/GeoIP2-City-Test.mmdb");
+        geoipStream = resource.openStream();
+        geoipFile = new File(resource.toURI());
     }
 
     @Test
     public void testDefaultLocaleFile() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .build();
-        this.testDefaultLocale(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).build();
+        testDefaultLocale(reader);
     }
 
     @Test
     public void testDefaultLocaleURL() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipStream)
-                .build();
-        this.testDefaultLocale(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipStream).build();
+        testDefaultLocale(reader);
         reader.close();
 
     }
 
-    private void testDefaultLocale(DatabaseReader reader) throws IOException,
-            GeoIp2Exception {
+    private void testDefaultLocale(DatabaseProvider reader) throws IOException, GeoIp2Exception {
         CityResponse city = reader.city(InetAddress.getByName("81.2.69.160"));
         assertEquals("London", city.getCity().getName());
         reader.close();
@@ -61,22 +65,19 @@ public class DatabaseReaderTest {
 
     @Test
     public void testLocaleListFile() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .locales(Arrays.asList("xx", "ru", "pt-BR", "es", "en"))
-                .build();
-        this.testLocaleList(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).locales(Arrays.asList("xx", "ru", "pt-BR", "es", "en"))
+                        .build();
+        testLocaleList(reader);
     }
 
     @Test
     public void testLocaleListURL() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .locales(Arrays.asList("xx", "ru", "pt-BR", "es", "en"))
-                .build();
-        this.testLocaleList(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).locales(Arrays.asList("xx", "ru", "pt-BR", "es", "en"))
+                        .build();
+        testLocaleList(reader);
     }
 
-    private void testLocaleList(DatabaseReader reader) throws IOException,
-            GeoIp2Exception {
+    private void testLocaleList(DatabaseProvider reader) throws IOException, GeoIp2Exception {
         CityResponse city = reader.city(InetAddress.getByName("81.2.69.160"));
         assertEquals("Лондон", city.getCity().getName());
         reader.close();
@@ -84,20 +85,17 @@ public class DatabaseReaderTest {
 
     @Test
     public void testMemoryModeFile() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .fileMode(Reader.FileMode.MEMORY).build();
-        this.testMemoryMode(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).fileMode(Reader.FileMode.MEMORY).build();
+        testMemoryMode(reader);
     }
 
     @Test
     public void testMemoryModeURL() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .fileMode(Reader.FileMode.MEMORY).build();
-        this.testMemoryMode(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).fileMode(Reader.FileMode.MEMORY).build();
+        testMemoryMode(reader);
     }
 
-    private void testMemoryMode(DatabaseReader reader) throws IOException,
-            GeoIp2Exception {
+    private void testMemoryMode(DatabaseProvider reader) throws IOException, GeoIp2Exception {
         CityResponse city = reader.city(InetAddress.getByName("81.2.69.160"));
         assertEquals("London", city.getCity().getName());
         assertEquals(100, city.getLocation().getAccuracyRadius().longValue());
@@ -105,29 +103,37 @@ public class DatabaseReaderTest {
     }
 
     @Test
+    public void testReload() throws Exception {
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).withReload(false).build();
+        testDefaultLocale(reader);
+    }
+
+    @Test
+    public void testReloadWithLazyInitialze() throws Exception {
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).withReload(true).build();
+        testDefaultLocale(reader);
+    }
+
+    @Test
     public void metadata() throws IOException {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .fileMode(Reader.FileMode.MEMORY).build();
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).fileMode(Reader.FileMode.MEMORY).build();
         assertEquals("GeoIP2-City", reader.getMetadata().getDatabaseType());
         reader.close();
     }
 
     @Test
     public void hasIpAddressFile() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .build();
-        this.hasIpAddress(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).build();
+        hasIpAddress(reader);
     }
 
     @Test
     public void hasIpAddressURL() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .build();
-        this.hasIpAddress(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).build();
+        hasIpAddress(reader);
     }
 
-    private void hasIpAddress(DatabaseReader reader) throws IOException,
-            GeoIp2Exception {
+    private void hasIpAddress(DatabaseProvider reader) throws IOException, GeoIp2Exception {
         CityResponse cio = reader.city(InetAddress.getByName("81.2.69.160"));
         assertEquals("81.2.69.160", cio.getTraits().getIpAddress());
         reader.close();
@@ -135,23 +141,19 @@ public class DatabaseReaderTest {
 
     @Test
     public void unknownAddressFile() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .build();
-        this.unknownAddress(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).build();
+        unknownAddress(reader);
     }
 
     @Test
     public void unknownAddressURL() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(this.geoipFile)
-                .build();
-        this.unknownAddress(reader);
+        DatabaseProvider reader = new DatabaseReader.Builder(geoipFile).build();
+        unknownAddress(reader);
     }
 
-    private void unknownAddress(DatabaseReader reader) throws IOException,
-            GeoIp2Exception {
-        this.exception.expect(AddressNotFoundException.class);
-        this.exception
-                .expectMessage(containsString("The address 10.10.10.10 is not in the database."));
+    private void unknownAddress(DatabaseProvider reader) throws IOException, GeoIp2Exception {
+        exception.expect(AddressNotFoundException.class);
+        exception.expectMessage(containsString("The address 10.10.10.10 is not in the database."));
         try {
             reader.city(InetAddress.getByName("10.10.10.10"));
         } finally {
@@ -161,18 +163,16 @@ public class DatabaseReaderTest {
 
     @Test
     public void testUnsupportedFileMode() throws IOException {
-        this.exception.expect(IllegalArgumentException.class);
-        this.exception.expectMessage(containsString("Only FileMode.MEMORY"));
-        new DatabaseReader.Builder(this.geoipStream).fileMode(
-                Reader.FileMode.MEMORY_MAPPED).build();
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(containsString("Only FileMode.MEMORY"));
+        new DatabaseReader.Builder(geoipStream).fileMode(Reader.FileMode.MEMORY_MAPPED).build();
     }
 
     @Test
     public void incorrectDatabaseMethod() throws Exception {
-        this.exception.expect(UnsupportedOperationException.class);
-        this.exception
-                .expectMessage(containsString("GeoIP2-City database using the isp method"));
-        DatabaseReader db = new DatabaseReader.Builder(this.geoipFile).build();
+        exception.expect(UnsupportedOperationException.class);
+        exception.expectMessage(containsString("GeoIP2-City database using the isp method"));
+        DatabaseProvider db = new DatabaseReader.Builder(geoipFile).build();
         try {
             db.isp(InetAddress.getByName("1.1.1.1"));
         } finally {
@@ -180,11 +180,9 @@ public class DatabaseReaderTest {
         }
     }
 
-
     @Test
     public void testAnonymousIp() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(
-                this.getFile("GeoIP2-Anonymous-IP-Test.mmdb")).build();
+        DatabaseProvider reader = new DatabaseReader.Builder(getFile("GeoIP2-Anonymous-IP-Test.mmdb")).build();
         InetAddress ipAddress = InetAddress.getByName("1.2.0.1");
         AnonymousIpResponse response = reader.anonymousIp(ipAddress);
         assertTrue(response.isAnonymous());
@@ -198,8 +196,7 @@ public class DatabaseReaderTest {
 
     @Test
     public void testConnectionType() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(
-                this.getFile("GeoIP2-Connection-Type-Test.mmdb")).build();
+        DatabaseProvider reader = new DatabaseReader.Builder(getFile("GeoIP2-Connection-Type-Test.mmdb")).build();
         InetAddress ipAddress = InetAddress.getByName("1.0.1.0");
 
         ConnectionTypeResponse response = reader.connectionType(ipAddress);
@@ -211,8 +208,7 @@ public class DatabaseReaderTest {
 
     @Test
     public void testDomain() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(
-                this.getFile("GeoIP2-Domain-Test.mmdb")).build();
+        DatabaseProvider reader = new DatabaseReader.Builder(getFile("GeoIP2-Domain-Test.mmdb")).build();
         InetAddress ipAddress = InetAddress.getByName("1.2.0.0");
         DomainResponse response = reader.domain(ipAddress);
         assertEquals("maxmind.com", response.getDomain());
@@ -222,8 +218,7 @@ public class DatabaseReaderTest {
 
     @Test
     public void testEnterprise() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(
-                getFile("GeoIP2-Enterprise-Test.mmdb")).build();
+        DatabaseProvider reader = new DatabaseReader.Builder(getFile("GeoIP2-Enterprise-Test.mmdb")).build();
         InetAddress ipAddress = InetAddress.getByName("74.209.24.0");
 
         EnterpriseResponse response = reader.enterprise(ipAddress);
@@ -239,13 +234,11 @@ public class DatabaseReaderTest {
 
     @Test
     public void testIsp() throws Exception {
-        DatabaseReader reader = new DatabaseReader.Builder(
-                this.getFile("GeoIP2-ISP-Test.mmdb")).build();
+        DatabaseProvider reader = new DatabaseReader.Builder(getFile("GeoIP2-ISP-Test.mmdb")).build();
         InetAddress ipAddress = InetAddress.getByName("1.128.0.0");
         IspResponse response = reader.isp(ipAddress);
         assertEquals(1221, response.getAutonomousSystemNumber().intValue());
-        assertEquals("Telstra Pty Ltd",
-                response.getAutonomousSystemOrganization());
+        assertEquals("Telstra Pty Ltd", response.getAutonomousSystemOrganization());
         assertEquals("Telstra Internet", response.getIsp());
         assertEquals("Telstra Internet", response.getOrganization());
 
@@ -254,8 +247,7 @@ public class DatabaseReaderTest {
     }
 
     private File getFile(String filename) throws URISyntaxException {
-        URL resource = DatabaseReaderTest.class
-                .getResource("/maxmind-db/test-data/" + filename);
+        URL resource = DatabaseReaderTest.class.getResource("/maxmind-db/test-data/" + filename);
         return new File(resource.toURI());
     }
 }

--- a/src/test/java/com/maxmind/geoip2/ReloadableDatabaseProviderTest.java
+++ b/src/test/java/com/maxmind/geoip2/ReloadableDatabaseProviderTest.java
@@ -1,0 +1,138 @@
+/* HEADER */
+package com.maxmind.geoip2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CityResponse;
+
+public class ReloadableDatabaseProviderTest {
+    private static final String TEST_IP_ADDRESS = "81.2.69.160";
+    private File geoipFile;
+
+    @Before
+    public void setup() throws URISyntaxException, IOException {
+        URL resource = DatabaseReaderTest.class.getResource("/maxmind-db/test-data/GeoIP2-City-Test.mmdb");
+        geoipFile = new File(resource.toURI());
+    }
+
+    @Test(expected = IOException.class)
+    public void eagerLoadingFileDoesNotExist() throws IOException, GeoIp2Exception {
+        File unknownFile = new File("unknown.mmdb");
+        DatabaseReader.Builder builder = new DatabaseReader.Builder(unknownFile);
+
+        try (DatabaseProvider provider = new ReloadableDatabaseProvider(builder, unknownFile)) {
+            fail("An exception should have been thrown!");
+        }
+    }
+
+    @Test
+    public void eagerLoadingFileExists() throws IOException, GeoIp2Exception {
+        DatabaseReader.Builder builder = new DatabaseReader.Builder(geoipFile);
+        DatabaseProvider reader = new ReloadableDatabaseProvider(builder, geoipFile);
+        testDefaultLocale(reader);
+    }
+
+    @Test
+    public void eagerLoadingReload() throws IOException, GeoIp2Exception {
+        DatabaseReader.Builder builder = new DatabaseReader.Builder(geoipFile);
+        Callable<Boolean> availableChecker = new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return true; // always report there are updates
+            }
+        };
+        // reader is eagerly initialized
+        DatabaseProvider reader = new ReloadableDatabaseProvider(builder, availableChecker, false);
+        // requesting look up will force reader to be reloaded
+        testDefaultLocale(reader);
+    }
+
+    @Test
+    public void eagerLoadingReloadNotAvailable() throws IOException, GeoIp2Exception {
+        DatabaseReader.Builder builder = new DatabaseReader.Builder(geoipFile);
+        final AtomicBoolean available = new AtomicBoolean(true);
+        Callable<Boolean> availableChecker = new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                if (available.get()) {
+                    // only report available once, then not available
+                    available.set(false);
+                    return true;
+                }
+                return available.get();
+            }
+        };
+
+        DatabaseProvider reader = new ReloadableDatabaseProvider(builder, availableChecker, false);
+        testDefaultLocale(reader);
+    }
+
+    @Test
+    public void lazyLoadingFileDoesNotExist() throws IOException, GeoIp2Exception {
+        File unknownFile = new File("unknown.mmdb");
+        DatabaseReader.Builder builder = new DatabaseReader.Builder(unknownFile);
+
+        try (DatabaseProvider reader = new ReloadableDatabaseProvider(builder, unknownFile, true)) {
+            // file should not be accessed yet
+        }
+    }
+
+    @Test
+    public void lazyLoadingFileExists() throws IOException, GeoIp2Exception {
+        DatabaseReader.Builder builder = new DatabaseReader.Builder(geoipFile);
+        ReloadableDatabaseProvider reader = new ReloadableDatabaseProvider(builder, geoipFile, true);
+        testDefaultLocale(reader);
+    }
+
+    @Test(expected = IOException.class)
+    public void databaseNotReady() throws IOException, GeoIp2Exception {
+        DatabaseReader.Builder builder = new DatabaseReader.Builder(geoipFile);
+        Callable<Boolean> availableChecker = new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return false;
+            }
+        };
+        assertFailedRead(builder, availableChecker, true);
+    }
+
+    @Test(expected = IOException.class)
+    public void databaseLoadFails() throws IOException, GeoIp2Exception {
+        DatabaseReader.Builder builder = new DatabaseReader.Builder(geoipFile);
+        Callable<Boolean> availableChecker = new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                throw new IllegalArgumentException("Database cannot be loaded");
+            }
+        };
+        assertFailedRead(builder, availableChecker, true);
+    }
+
+    private void testDefaultLocale(DatabaseProvider reader) throws IOException, GeoIp2Exception {
+        CityResponse city = reader.city(InetAddress.getByName(TEST_IP_ADDRESS));
+        assertEquals("London", city.getCity().getName());
+        reader.close();
+    }
+
+    private void assertFailedRead(DatabaseReader.Builder builder, Callable<Boolean> availableChecker, boolean lazyInitialization)
+                    throws IOException, GeoIp2Exception, UnknownHostException {
+        try (ReloadableDatabaseProvider reader = new ReloadableDatabaseProvider(builder, availableChecker, lazyInitialization)) {
+            reader.city(InetAddress.getByName(TEST_IP_ADDRESS));
+            fail("An exception should have been thrown!");
+        }
+    }
+}


### PR DESCRIPTION
Whilst it's possible to roll your own solution to reloading updates to the database file, it seems sensible that this would be provided by the library.  It would make sense to add a builder option that allows the database to be updated when the file has been modified.  Furthermore as the database file might not always be there initially (e.g. it's downloaded on first application start up) it would also make sense to allow the reloading to deal with this as well.  This allows a client to start the application with a reader but only when the file is available will it start successfully responding to requests.

The second commit adds the ability for the file to be downloaded via a direct url, replacing the existing file when an update is available.  It also handles storing the last checksum to ensure on restart it doesn't always download the latest version. Whilst there is an external tool that provides the facility to update the file.  It's not always possibly to install this.  In this case it's easy to set up a TimerTask to run periodically checking for updates.