### PR TITLE
DatabaseReader method to check type support

### DIFF
--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -170,12 +170,11 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
     private <T> T get(InetAddress ipAddress, Class<T> cls,
                       String type) throws IOException, AddressNotFoundException {
 
-        String databaseType = this.getMetadata().getDatabaseType();
-        if (!databaseType.contains(type)) {
+        if (!isTypeSupported(type)) {
             String caller = Thread.currentThread().getStackTrace()[2]
                     .getMethodName();
             throw new UnsupportedOperationException(
-                    "Invalid attempt to open a " + databaseType
+                    "Invalid attempt to open a " + this.getMetadata().getDatabaseType()
                             + " database using the " + caller + " method");
         }
 
@@ -325,5 +324,16 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
      */
     public Metadata getMetadata() {
         return this.reader.getMetadata();
+    }
+
+    /**
+     * Checks if the database type is supported
+     *
+     * @param type database type to check
+     * @return if the database type is supported
+     */
+    public boolean isTypeSupported(String type) {
+        String databaseType = this.getMetadata().getDatabaseType();
+        return databaseType.contains(type);
     }
 }

--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -327,10 +327,10 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
     }
 
     /**
-     * Checks if the database type is supported
+     * Checks if type is supported
      *
-     * @param type database type to check
-     * @return if the database type is supported
+     * @param type type to check for support
+     * @return if the type is supported
      */
     public boolean isTypeSupported(String type) {
         String databaseType = this.getMetadata().getDatabaseType();

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -272,6 +272,15 @@ public class DatabaseReaderTest {
         reader.close();
     }
 
+    @Test
+    public void testTypeSupported() throws Exception {
+        DatabaseReader reader = new DatabaseReader.Builder(
+                getFile("GeoIP2-Enterprise-Test.mmdb")).build();
+
+        assertTrue(reader.isTypeSupported("Enterprise"));
+        assertFalse(reader.isTypeSupported("City"));
+    }
+
     private File getFile(String filename) throws URISyntaxException {
         URL resource = DatabaseReaderTest.class
                 .getResource("/maxmind-db/test-data/" + filename);


### PR DESCRIPTION
Method was needed to decide database type so that we know what method to call to get valid response.
e.g. `city()` and `enterprise()` return `AbstractCityResponse` so we can use both for our purpose.