### PR TITLE
Adds cityOrNull & countryOrNull methods for cases when the IP is unkn…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ addons:
 language: java
 matrix:
   include:
-    - jdk: openjdk7
-      dist: trusty
     - jdk: openjdk8
     - jdk: openjdk11
       env: RUN_SNYK=true

--- a/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
@@ -3,31 +3,30 @@ package com.maxmind.geoip2;
 import com.maxmind.geoip2.exception.GeoIp2Exception;
 import com.maxmind.geoip2.model.*;
 
+import java.util.Optional;
+
 import java.io.IOException;
 import java.net.InetAddress;
 
 public interface DatabaseProvider extends GeoIp2Provider {
     
     /**
-     * Same as {@link #country(InetAddress)} but return null when the IP is not in our database.
      * 
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return A Country model for the requested IP address or empty if the IP address is not in the DB.
+     * @throws GeoIp2Exception if there is an error looking up the IP
+     * @throws IOException     if there is an IO error
      */
-    CountryResponse tryCountry(InetAddress ipAddress) throws IOException,
+    Optional<CountryResponse> tryCountry(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
     
     /**
-     * Same as {@link #city(InetAddress)} but returns null when the IP is not in our database.
-     * 
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return A City model for the requested IP address or empty if the IP address is not in the DB.
+     * @throws GeoIp2Exception if there is an error looking up the IP
+     * @throws IOException     if there is an IO error
      */
-    public CityResponse tryCity(InetAddress ipAddress) throws IOException,
+    Optional<CityResponse> tryCity(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
     
     /**
@@ -42,14 +41,14 @@ public interface DatabaseProvider extends GeoIp2Provider {
             GeoIp2Exception;
     
     /**
-     * Same as {@link #anonymousIp(InetAddress)} but returns null when the IP is not in our database.
-     * 
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
+     * Look up an IP address in a GeoIP2 Anonymous IP.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return a AnonymousIpResponse for the requested IP address or empty if the IP address is not in the DB.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException                          if there is an IO error
      */
-    AnonymousIpResponse tryAnonymousIp(InetAddress ipAddress) throws IOException,
+    Optional<AnonymousIpResponse> tryAnonymousIp(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
 
     /**
@@ -64,14 +63,14 @@ public interface DatabaseProvider extends GeoIp2Provider {
             GeoIp2Exception;
     
     /**
-     * Same as {@link #asn(InetAddress)} but returns null when the IP is not in our database.
-     * 
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
+     * Look up an IP address in a GeoLite2 ASN database.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return an IspResponse for the requested IP address or empty if the IP address is not in the DB.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException                          if there is an IO error
      */
-    AsnResponse tryAsn(InetAddress ipAddress) throws IOException,
+    Optional<AsnResponse> tryAsn(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
 
     /**
@@ -86,14 +85,14 @@ public interface DatabaseProvider extends GeoIp2Provider {
             throws IOException, GeoIp2Exception;
     
     /**
-     * Same as {@link #connectionType(InetAddress)} but returns null when the IP is not in our database.
-     * 
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
+     * Look up an IP address in a GeoIP2 Connection Type database.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return a ConnectTypeResponse for the requested IP address or empty if the IP address is not in the DB.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException                          if there is an IO error
      */
-    ConnectionTypeResponse tryConnectionType(InetAddress ipAddress)
+    Optional<ConnectionTypeResponse> tryConnectionType(InetAddress ipAddress)
             throws IOException, GeoIp2Exception;
 
     /**
@@ -108,14 +107,14 @@ public interface DatabaseProvider extends GeoIp2Provider {
             GeoIp2Exception;
     
     /**
-     * Same as {@link #domain(InetAddress)} but returns null when the IP is not in our database.
-     * 
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
+     * Look up an IP address in a GeoIP2 Domain database.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return a DomainResponse for the requested IP address or empty if the IP address is not in the DB.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException                          if there is an IO error
      */
-    DomainResponse tryDomain(InetAddress ipAddress) throws IOException,
+    Optional<DomainResponse> tryDomain(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
 
     /**
@@ -130,14 +129,14 @@ public interface DatabaseProvider extends GeoIp2Provider {
             GeoIp2Exception;
     
     /**
-     * Same as {@link #enterprise(InetAddress)} but returns null when the IP is not in our database.
-     * 
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
+     * Look up an IP address in a GeoIP2 Enterprise database.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return an EnterpriseResponse for the requested IP address or empty if the IP address is not in the DB.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException                          if there is an IO error
      */
-    EnterpriseResponse tryEnterprise(InetAddress ipAddress) throws IOException,
+    Optional<EnterpriseResponse> tryEnterprise(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
 
     /**
@@ -152,12 +151,13 @@ public interface DatabaseProvider extends GeoIp2Provider {
             GeoIp2Exception;
     
     /**
-     * Same as {@link #isp(InetAddress)} but returns null when the IP is not in our database.
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
+     * Look up an IP address in a GeoIP2 ISP database.
+     *
+     * @param ipAddress IPv4 or IPv6 address to lookup or empty if the IP address is not in the DB.
+     * @return an IspResponse for the requested IP address.
+     * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
+     * @throws java.io.IOException                          if there is an IO error
      */
-    IspResponse tryIsp(InetAddress ipAddress) throws IOException,
+    Optional<IspResponse> tryIsp(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
 }

--- a/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
@@ -7,6 +7,29 @@ import java.io.IOException;
 import java.net.InetAddress;
 
 public interface DatabaseProvider extends GeoIp2Provider {
+    
+    /**
+     * Same as {@link #country(InetAddress)} but return null when the IP is not in our database.
+     * 
+     * @param ipAddress
+     * @return
+     * @throws IOException
+     * @throws GeoIp2Exception
+     */
+    CountryResponse tryCountry(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception;
+    
+    /**
+     * Same as {@link #city(InetAddress)} but returns null when the IP is not in our database.
+     * 
+     * @param ipAddress
+     * @return
+     * @throws IOException
+     * @throws GeoIp2Exception
+     */
+    public CityResponse tryCity(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception;
+    
     /**
      * Look up an IP address in a GeoIP2 Anonymous IP.
      *
@@ -16,6 +39,17 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @throws java.io.IOException                          if there is an IO error
      */
     AnonymousIpResponse anonymousIp(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception;
+    
+    /**
+     * Same as {@link #anonymousIp(InetAddress)} but returns null when the IP is not in our database.
+     * 
+     * @param ipAddress
+     * @return
+     * @throws IOException
+     * @throws GeoIp2Exception
+     */
+    AnonymousIpResponse tryAnonymousIp(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
 
     /**
@@ -28,6 +62,17 @@ public interface DatabaseProvider extends GeoIp2Provider {
      */
     AsnResponse asn(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
+    
+    /**
+     * Same as {@link #asn(InetAddress)} but returns null when the IP is not in our database.
+     * 
+     * @param ipAddress
+     * @return
+     * @throws IOException
+     * @throws GeoIp2Exception
+     */
+    AsnResponse tryAsn(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 Connection Type database.
@@ -38,6 +83,17 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @throws java.io.IOException                          if there is an IO error
      */
     ConnectionTypeResponse connectionType(InetAddress ipAddress)
+            throws IOException, GeoIp2Exception;
+    
+    /**
+     * Same as {@link #connectionType(InetAddress)} but returns null when the IP is not in our database.
+     * 
+     * @param ipAddress
+     * @return
+     * @throws IOException
+     * @throws GeoIp2Exception
+     */
+    ConnectionTypeResponse tryConnectionType(InetAddress ipAddress)
             throws IOException, GeoIp2Exception;
 
     /**
@@ -50,6 +106,17 @@ public interface DatabaseProvider extends GeoIp2Provider {
      */
     DomainResponse domain(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
+    
+    /**
+     * Same as {@link #domain(InetAddress)} but returns null when the IP is not in our database.
+     * 
+     * @param ipAddress
+     * @return
+     * @throws IOException
+     * @throws GeoIp2Exception
+     */
+    DomainResponse tryDomain(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 Enterprise database.
@@ -61,6 +128,17 @@ public interface DatabaseProvider extends GeoIp2Provider {
      */
     EnterpriseResponse enterprise(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
+    
+    /**
+     * Same as {@link #enterprise(InetAddress)} but returns null when the IP is not in our database.
+     * 
+     * @param ipAddress
+     * @return
+     * @throws IOException
+     * @throws GeoIp2Exception
+     */
+    EnterpriseResponse tryEnterprise(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception;
 
     /**
      * Look up an IP address in a GeoIP2 ISP database.
@@ -71,5 +149,15 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @throws java.io.IOException                          if there is an IO error
      */
     IspResponse isp(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception;
+    
+    /**
+     * Same as {@link #isp(InetAddress)} but returns null when the IP is not in our database.
+     * @param ipAddress
+     * @return
+     * @throws IOException
+     * @throws GeoIp2Exception
+     */
+    IspResponse tryIsp(InetAddress ipAddress) throws IOException,
             GeoIp2Exception;
 }

--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -266,7 +266,7 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
     }
     
     /**
-     * Same as {@link #city(InetAddress)} but returns null when the IP is no in our database.
+     * Same as {@link #city(InetAddress)} but returns null when the IP is not in our database.
      * 
      * @param ipAddress
      * @return

--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -247,14 +247,8 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
         return this.get(ipAddress, CountryResponse.class, "Country");
     }
     
-    /**
-     * Same as {@link #country(InetAddress)} but return null when the IP is not in our database.
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
-     */
-    public CountryResponse countryOrNull(InetAddress ipAddress) throws IOException,
+    @Override
+    public CountryResponse tryCountry(InetAddress ipAddress) throws IOException,
             GeoIp2Exception {
         return this.getOrNull(ipAddress, CountryResponse.class, "Country", 0);
     }
@@ -265,15 +259,8 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
         return this.get(ipAddress, CityResponse.class, "City");
     }
     
-    /**
-     * Same as {@link #city(InetAddress)} but returns null when the IP is not in our database.
-     * 
-     * @param ipAddress
-     * @return
-     * @throws IOException
-     * @throws GeoIp2Exception
-     */
-    public CityResponse cityOrNull(InetAddress ipAddress) throws IOException,
+    @Override
+    public CityResponse tryCity(InetAddress ipAddress) throws IOException,
             GeoIp2Exception {
         return this.getOrNull(ipAddress, CityResponse.class, "City", 0);
     }
@@ -291,6 +278,12 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
             GeoIp2Exception {
         return this.get(ipAddress, AnonymousIpResponse.class, "GeoIP2-Anonymous-IP");
     }
+    
+    @Override
+    public AnonymousIpResponse tryAnonymousIp(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception {
+        return this.getOrNull(ipAddress, AnonymousIpResponse.class, "GeoIP2-Anonymous-IP", 0);
+    }
 
     /**
      * Look up an IP address in a GeoLite2 ASN database.
@@ -304,6 +297,12 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
     public AsnResponse asn(InetAddress ipAddress) throws IOException,
             GeoIp2Exception {
         return this.get(ipAddress, AsnResponse.class, "GeoLite2-ASN");
+    }
+    
+    @Override
+    public AsnResponse tryAsn(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception {
+        return this.getOrNull(ipAddress, AsnResponse.class, "GeoLite2-ASN", 0);
     }
 
     /**
@@ -320,6 +319,13 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
         return this.get(ipAddress, ConnectionTypeResponse.class,
                 "GeoIP2-Connection-Type");
     }
+    
+    @Override
+    public ConnectionTypeResponse tryConnectionType(InetAddress ipAddress)
+            throws IOException, GeoIp2Exception {
+        return this.getOrNull(ipAddress, ConnectionTypeResponse.class,
+                "GeoIP2-Connection-Type", 0);
+    }
 
     /**
      * Look up an IP address in a GeoIP2 Domain database.
@@ -335,6 +341,13 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
         return this
                 .get(ipAddress, DomainResponse.class, "GeoIP2-Domain");
     }
+    
+    @Override
+    public DomainResponse tryDomain(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception {
+        return this
+                .getOrNull(ipAddress, DomainResponse.class, "GeoIP2-Domain", 0);
+    }
 
     /**
      * Look up an IP address in a GeoIP2 Enterprise database.
@@ -348,6 +361,12 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
     public EnterpriseResponse enterprise(InetAddress ipAddress) throws IOException,
             GeoIp2Exception {
         return this.get(ipAddress, EnterpriseResponse.class, "Enterprise");
+    }
+    
+    @Override
+    public EnterpriseResponse tryEnterprise(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception {
+        return this.getOrNull(ipAddress, EnterpriseResponse.class, "Enterprise", 0);
     }
 
 
@@ -363,6 +382,12 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
     public IspResponse isp(InetAddress ipAddress) throws IOException,
             GeoIp2Exception {
         return this.get(ipAddress, IspResponse.class, "GeoIP2-ISP");
+    }
+    
+    @Override
+    public IspResponse tryIsp(InetAddress ipAddress) throws IOException,
+            GeoIp2Exception {
+        return this.getOrNull(ipAddress, IspResponse.class, "GeoIP2-ISP", 0);
     }
 
     /**

--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -171,7 +171,7 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
     private <T> T getOrThrowException(InetAddress ipAddress, Class<T> cls,
                       String type) throws IOException, AddressNotFoundException {
         Optional<T> t = get(ipAddress, cls, type, 1);
-        if(t.isEmpty()) {
+        if(!t.isPresent()) {
             throw new AddressNotFoundException("The address "
                     + ipAddress.getHostAddress() + " is not in the database.");
         }

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -159,7 +159,7 @@ public class DatabaseReaderTest {
     private void unknownAddress(DatabaseReader reader) throws IOException,
             GeoIp2Exception {
         try {
-            Assert.assertNull(reader.cityOrNull(InetAddress.getByName("10.10.10.10")));
+            assertNull(reader.cityOrNull(InetAddress.getByName("10.10.10.10")));
             
             this.exception.expect(AddressNotFoundException.class);
             this.exception

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -159,7 +159,7 @@ public class DatabaseReaderTest {
     private void unknownAddress(DatabaseReader reader) throws IOException,
             GeoIp2Exception {
         try {
-            assertNull(reader.tryCity(InetAddress.getByName("10.10.10.10")));
+            assertFalse(reader.tryCity(InetAddress.getByName("10.10.10.10")).isPresent());
             
             this.exception.expect(AddressNotFoundException.class);
             this.exception

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -158,10 +158,13 @@ public class DatabaseReaderTest {
 
     private void unknownAddress(DatabaseReader reader) throws IOException,
             GeoIp2Exception {
-        this.exception.expect(AddressNotFoundException.class);
-        this.exception
-                .expectMessage(containsString("The address 10.10.10.10 is not in the database."));
         try {
+            Assert.assertNull(reader.cityOrNull(InetAddress.getByName("10.10.10.10")));
+            
+            this.exception.expect(AddressNotFoundException.class);
+            this.exception
+                    .expectMessage(containsString("The address 10.10.10.10 is not in the database."));
+        
             reader.city(InetAddress.getByName("10.10.10.10"));
         } finally {
             reader.close();

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -159,7 +159,7 @@ public class DatabaseReaderTest {
     private void unknownAddress(DatabaseReader reader) throws IOException,
             GeoIp2Exception {
         try {
-            assertNull(reader.cityOrNull(InetAddress.getByName("10.10.10.10")));
+            assertNull(reader.tryCity(InetAddress.getByName("10.10.10.10")));
             
             this.exception.expect(AddressNotFoundException.class);
             this.exception


### PR DESCRIPTION
…own. #28

Throwing exceptions is expensive and should generally be reserved for
exceptional circumstances. This change adds to the DatabaseReader support
for returning null instead of an exception when the IP address is not found.

This shows an example of the `xOrNull` solution to avoid the expensive exception. I wasn't sure if you wanted this on an interface, perhaps it should be in the the `DatabaseProvider` interface.

I did not return `Optional` as I assume that support for java7 is wanted.