### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,7 @@
             <artifactId>wiremock</artifactId>
             <version>2.27.2</version>
             <scope>test</scope>
-        </dependency>
-        
-        
+        </dependency>   
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-objects</artifactId>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
geoip2
{groupId='org.skyscreamer', artifactId='jsonassert'}
{groupId='org.slf4j', artifactId='slf4j-simple'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
