### PR TITLE
Add MCC/MNC support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        version: [ 8, 9, 10, 11, 12, 13, 14, 15 ]
+        version: [ 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ CHANGELOG
 2.16.0
 -------------------
 
+* Support for mobile country code (MCC) and mobile network codes (MNC) was
+￼ added for the GeoIP2 ISP and Enterprise databases as well as the GeoIP2
+￼ City and Insights web services. `getMobileCountryCode()` and
+￼ `getMobileNetworkCode()` were added to `com.maxmind.geoip2.model.IspResponse`
+￼ for the GeoIP2 ISP database and `com.maxmind.geoip2.record.Traits` for the
+  Enterprise database and the GeoIP2 City and Insights web services. We expect
+  this data to be available by late January, 2022.
 * Deprecated model constructors that exist for backwards compatibility.
   These constructors are not generally used by users of this library
   directly except perhaps when mocking the reader in tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+2.16.0
+-------------------
+
+* Deprecated model constructors that exist for backwards compatibility.
+  These constructors are not generally used by users of this library
+  directly except perhaps when mocking the reader in tests.
+
 2.15.0 (2020-10-14)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -532,6 +532,6 @@ The GeoIP2 Java API uses [Semantic Versioning](https://semver.org/).
 
 ## Copyright and License ##
 
-This software is Copyright (c) 2013-2020 by MaxMind, Inc.
+This software is Copyright (c) 2013-2021 by MaxMind, Inc.
 
 This is free software, licensed under the Apache License, Version 2.0.

--- a/src/main/java/com/maxmind/geoip2/WebServiceClient.java
+++ b/src/main/java/com/maxmind/geoip2/WebServiceClient.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.maxmind.geoip2.exception.*;
 import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.model.CountryResponse;
@@ -119,9 +120,10 @@ public class WebServiceClient implements GeoIp2Provider, Closeable {
         this.licenseKey = builder.licenseKey;
         this.accountId = builder.accountId;
 
-        mapper = new ObjectMapper();
-        mapper.disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS);
-        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        mapper = JsonMapper.builder()
+                .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .build();
 
         RequestConfig.Builder configBuilder = RequestConfig.custom()
                 .setConnectTimeout(builder.connectTimeout)

--- a/src/main/java/com/maxmind/geoip2/model/AbstractResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AbstractResponse.java
@@ -3,6 +3,7 @@ package com.maxmind.geoip2.model;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 
@@ -14,10 +15,12 @@ public abstract class AbstractResponse {
      * @throws IOException if there is an error serializing the object to JSON.
      */
     public String toJson() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(Include.NON_NULL);
-        mapper.setSerializationInclusion(Include.NON_EMPTY);
-        mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
+        JsonMapper mapper = JsonMapper.builder()
+                .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
+                .serializationInclusion(Include.NON_NULL)
+                .serializationInclusion(Include.NON_EMPTY)
+                .build();
+
         return mapper.writeValueAsString(this);
     }
 

--- a/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
@@ -31,7 +31,9 @@ public class AnonymousIpResponse extends AbstractResponse {
     /**
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
-     */    public AnonymousIpResponse(
+     */
+    @Deprecated
+    public AnonymousIpResponse(
             String ipAddress,
             boolean isAnonymous,
             boolean isAnonymousVpn,
@@ -45,7 +47,9 @@ public class AnonymousIpResponse extends AbstractResponse {
     /**
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
-     */    public AnonymousIpResponse(
+     */
+    @Deprecated
+    public AnonymousIpResponse(
             String ipAddress,
             boolean isAnonymous,
             boolean isAnonymousVpn,

--- a/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AnonymousIpResponse.java
@@ -28,8 +28,10 @@ public class AnonymousIpResponse extends AbstractResponse {
         this(null, false, false, false, false, false);
     }
 
-    // This is for compatibility and should be removed if we do a major release.
-    public AnonymousIpResponse(
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */    public AnonymousIpResponse(
             String ipAddress,
             boolean isAnonymous,
             boolean isAnonymousVpn,
@@ -40,8 +42,10 @@ public class AnonymousIpResponse extends AbstractResponse {
         this(ipAddress, isAnonymous, isAnonymousVpn, isHostingProvider, isPublicProxy, isTorExitNode, null);
     }
 
-    // This is for compatibility and should be removed if we do a major release.
-    public AnonymousIpResponse(
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */    public AnonymousIpResponse(
             String ipAddress,
             boolean isAnonymous,
             boolean isAnonymousVpn,

--- a/src/main/java/com/maxmind/geoip2/model/AsnResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AsnResponse.java
@@ -28,6 +28,7 @@ public class AsnResponse extends AbstractResponse {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public AsnResponse(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,

--- a/src/main/java/com/maxmind/geoip2/model/AsnResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/AsnResponse.java
@@ -24,6 +24,10 @@ public class AsnResponse extends AbstractResponse {
         this((Integer) null, null, null, null);
     }
 
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public AsnResponse(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,

--- a/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
@@ -72,6 +72,7 @@ public class ConnectionTypeResponse extends AbstractResponse {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public ConnectionTypeResponse(
             ConnectionType connectionType,
             String ipAddress

--- a/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/ConnectionTypeResponse.java
@@ -68,6 +68,10 @@ public class ConnectionTypeResponse extends AbstractResponse {
         this(null, null);
     }
 
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public ConnectionTypeResponse(
             ConnectionType connectionType,
             String ipAddress

--- a/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
@@ -27,6 +27,7 @@ public class DomainResponse extends AbstractResponse {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public DomainResponse(
             String domain,
             String ipAddress

--- a/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/DomainResponse.java
@@ -23,6 +23,10 @@ public class DomainResponse extends AbstractResponse {
         this(null, null);
     }
 
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public DomainResponse(
             String domain,
             String ipAddress

--- a/src/main/java/com/maxmind/geoip2/model/IspResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/IspResponse.java
@@ -15,6 +15,8 @@ public class IspResponse extends AsnResponse {
 
     private final String isp;
     private final String organization;
+    private final String mobileCountryCode;
+    private final String mobileNetworkCode;
 
     IspResponse() {
         this(null, null, null, null, null);
@@ -34,16 +36,50 @@ public class IspResponse extends AsnResponse {
         this(autonomousSystemNumber, autonomousSystemOrganization, ipAddress, isp, organization, null);
     }
 
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
+    public IspResponse(
+            Integer autonomousSystemNumber,
+            String autonomousSystemOrganization,
+            String ipAddress,
+            String isp,
+            String organization,
+            Network network
+    ) {
+        this(autonomousSystemNumber, autonomousSystemOrganization, ipAddress, isp, null, null, organization, network);
+    }
+
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
+    public IspResponse(
+            Long autonomousSystemNumber,
+            String autonomousSystemOrganization,
+            String ipAddress,
+            String isp,
+            String organization,
+            Network network
+    ) {
+        this(autonomousSystemNumber, autonomousSystemOrganization, ipAddress, isp, null, null, organization, network);
+    }
+
     public IspResponse(
             @JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
             @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,
             @JacksonInject("ip_address") @JsonProperty("ip_address") String ipAddress,
             @JsonProperty("isp") String isp,
+            @JsonProperty("mobile_country_code") String mobileCountryCode,
+            @JsonProperty("mobile_network_code") String mobileNetworkCode,
             @JsonProperty("organization") String organization,
             @JacksonInject("network") @JsonProperty("network") @JsonDeserialize(using = NetworkDeserializer.class) Network network
     ) {
         super(autonomousSystemNumber, autonomousSystemOrganization, ipAddress, network);
         this.isp = isp;
+        this.mobileCountryCode = mobileCountryCode;
+        this.mobileNetworkCode = mobileNetworkCode;
         this.organization = organization;
     }
 
@@ -53,6 +89,8 @@ public class IspResponse extends AsnResponse {
             @MaxMindDbParameter(name="autonomous_system_organization") String autonomousSystemOrganization,
             @MaxMindDbParameter(name="ip_address") String ipAddress,
             @MaxMindDbParameter(name="isp") String isp,
+            @MaxMindDbParameter(name="mobile_country_code") String mobileCountryCode,
+            @MaxMindDbParameter(name="mobile_network_code") String mobileNetworkCode,
             @MaxMindDbParameter(name="organization") String organization,
             @MaxMindDbParameter(name="network") Network network
     ) {
@@ -61,6 +99,8 @@ public class IspResponse extends AsnResponse {
             autonomousSystemOrganization,
             ipAddress,
             isp,
+            mobileCountryCode,
+            mobileNetworkCode,
             organization,
             network
         );
@@ -76,6 +116,8 @@ public class IspResponse extends AsnResponse {
             response.getAutonomousSystemOrganization(),
             ipAddress,
             response.getIsp(),
+            response.getMobileCountryCode(),
+            response.getMobileNetworkCode(),
             response.getOrganization(),
             network
         );
@@ -86,6 +128,26 @@ public class IspResponse extends AsnResponse {
      */
     public String getIsp() {
         return this.isp;
+    }
+
+    /**
+     * @return The <a href="https://en.wikipedia.org/wiki/Mobile_country_code">
+     * mobile country code (MCC)</a> associated with the IP address and ISP.
+     * This property is available from the City and Insights web services and
+     * the GeoIP2 Enterprise database.
+     */
+    public String getMobileCountryCode() {
+        return this.mobileCountryCode;
+    }
+
+    /**
+     * @return The <a href="https://en.wikipedia.org/wiki/Mobile_country_code">
+     * mobile network code (MNC)</a> associated with the IP address and ISP.
+     * This property is available from the City and Insights web services and
+     * the GeoIP2 Enterprise database.
+     */
+    public String getMobileNetworkCode() {
+        return this.mobileNetworkCode;
     }
 
     /**

--- a/src/main/java/com/maxmind/geoip2/model/IspResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/IspResponse.java
@@ -20,6 +20,10 @@ public class IspResponse extends AsnResponse {
         this(null, null, null, null, null);
     }
 
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public IspResponse(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,

--- a/src/main/java/com/maxmind/geoip2/model/IspResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/IspResponse.java
@@ -26,6 +26,7 @@ public class IspResponse extends AsnResponse {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public IspResponse(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -40,6 +41,7 @@ public class IspResponse extends AsnResponse {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public IspResponse(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -55,6 +57,7 @@ public class IspResponse extends AsnResponse {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public IspResponse(
             Long autonomousSystemNumber,
             String autonomousSystemOrganization,

--- a/src/main/java/com/maxmind/geoip2/record/AbstractRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractRecord.java
@@ -3,6 +3,7 @@ package com.maxmind.geoip2.record;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 
@@ -14,10 +15,12 @@ public abstract class AbstractRecord {
      * @throws IOException if there is an error serializing the object to JSON.
      */
     public String toJson() throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-        mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
+        JsonMapper mapper = JsonMapper.builder()
+                .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
+                .serializationInclusion(JsonInclude.Include.NON_NULL)
+                .serializationInclusion(JsonInclude.Include.NON_EMPTY)
+                .build();
+
         return mapper.writeValueAsString(this);
     }
 

--- a/src/main/java/com/maxmind/geoip2/record/Country.java
+++ b/src/main/java/com/maxmind/geoip2/record/Country.java
@@ -34,6 +34,7 @@ public class Country extends AbstractNamedRecord {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public Country(
             List<String> locales,
             Integer confidence,

--- a/src/main/java/com/maxmind/geoip2/record/Country.java
+++ b/src/main/java/com/maxmind/geoip2/record/Country.java
@@ -30,8 +30,10 @@ public class Country extends AbstractNamedRecord {
         this(null, null, (Integer) null, false, null, null);
     }
 
-    // This method is for backwards compatibility. We should remove it when we
-    // do a major release.
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public Country(
             List<String> locales,
             Integer confidence,

--- a/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
+++ b/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
@@ -30,8 +30,10 @@ public final class RepresentedCountry extends Country {
         this(null, null, (Integer) null, false, null, null, null);
     }
 
-    // This method is for backwards compatibility. We should remove it when we
-    // do a major release.
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public RepresentedCountry(
             List<String> locales,
             Integer confidence,

--- a/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
+++ b/src/main/java/com/maxmind/geoip2/record/RepresentedCountry.java
@@ -34,6 +34,7 @@ public final class RepresentedCountry extends Country {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public RepresentedCountry(
             List<String> locales,
             Integer confidence,

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -57,8 +57,10 @@ public final class Traits extends AbstractRecord {
                 network, null, null, null, null);
     }
 
-    // This is for back-compat. If we ever do a major release, it should be
-    // removed.
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -75,8 +77,10 @@ public final class Traits extends AbstractRecord {
                 organization, userType);
     }
 
-    // This is for back-compat. If we ever do a major release, it should be
-    // removed.
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -95,8 +99,10 @@ public final class Traits extends AbstractRecord {
                 false, isSatelliteProvider, false, isp, null, organization, userType, null, null);
     }
 
-    // This is for back-compat. If we ever do a major release, it should be
-    // removed.
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -121,8 +127,10 @@ public final class Traits extends AbstractRecord {
                 null, organization, userType, null, null);
     }
 
-    // This is for back-compat. If we ever do a major release, it should be
-    // removed.
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -36,6 +36,8 @@ public final class Traits extends AbstractRecord {
     private final boolean isSatelliteProvider;
     private final boolean isTorExitNode;
     private final String isp;
+    private final String mobileCountryCode;
+    private final String mobileNetworkCode;
     private final Network network;
     private final String organization;
     private final String userType;
@@ -160,6 +162,74 @@ public final class Traits extends AbstractRecord {
                 staticIpScore);
     }
 
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
+    public Traits(
+            Integer autonomousSystemNumber,
+            String autonomousSystemOrganization,
+            ConnectionType connectionType,
+            String domain,
+            String ipAddress,
+            boolean isAnonymous,
+            boolean isAnonymousProxy,
+            boolean isAnonymousVpn,
+            boolean isHostingProvider,
+            boolean isLegitimateProxy,
+            boolean isPublicProxy,
+            boolean isResidentialProxy,
+            boolean isSatelliteProvider,
+            boolean isTorExitNode,
+            String isp,
+            Network network,
+            String organization,
+            String userType,
+            Integer userCount,
+            Double staticIpScore
+    ) {
+        this(autonomousSystemNumber, autonomousSystemOrganization,
+                connectionType, domain, ipAddress, isAnonymous,
+                isAnonymousProxy, isAnonymousVpn, isHostingProvider,
+                isLegitimateProxy, isPublicProxy, isResidentialProxy, isSatelliteProvider,
+                isTorExitNode, isp, null, null, network,
+                organization, userType, userCount, staticIpScore);
+    }
+
+    /**
+     * @deprecated This constructor exists for backwards compatibility. Will be
+     * removed in the next major release.
+     */
+    public Traits(
+            Long autonomousSystemNumber,
+            String autonomousSystemOrganization,
+            String connectionType,
+            String domain,
+            String ipAddress,
+            Boolean isAnonymous,
+            Boolean isAnonymousProxy,
+            Boolean isAnonymousVpn,
+            Boolean isHostingProvider,
+            Boolean isLegitimateProxy,
+            Boolean isPublicProxy,
+            Boolean isResidentialProxy,
+            Boolean isSatelliteProvider,
+            Boolean isTorExitNode,
+            String isp,
+            Network network,
+            String organization,
+            String userType,
+            Integer userCount,
+            Double staticIpScore
+    ) {
+        this(autonomousSystemNumber, autonomousSystemOrganization,
+                connectionType, domain, ipAddress, isAnonymous,
+                isAnonymousProxy, isAnonymousVpn, isHostingProvider,
+                isLegitimateProxy, isPublicProxy, isResidentialProxy, isSatelliteProvider,
+                isTorExitNode, isp, null, null, network,
+                organization, userType, userCount, staticIpScore);
+    }
+
     public Traits(
             @JsonProperty("autonomous_system_number") Integer autonomousSystemNumber,
             @JsonProperty("autonomous_system_organization") String autonomousSystemOrganization,
@@ -176,6 +246,8 @@ public final class Traits extends AbstractRecord {
             @JsonProperty("is_satellite_provider") boolean isSatelliteProvider,
             @JsonProperty("is_tor_exit_node") boolean isTorExitNode,
             @JsonProperty("isp") String isp,
+            @JsonProperty("mobile_country_code") String mobileCountryCode,
+            @JsonProperty("mobile_network_code") String mobileNetworkCode,
             @JacksonInject("network") @JsonProperty("network") @JsonDeserialize(using = NetworkDeserializer.class) Network network,
             @JsonProperty("organization") String organization,
             @JsonProperty("user_type") String userType,
@@ -197,6 +269,8 @@ public final class Traits extends AbstractRecord {
         this.isSatelliteProvider = isSatelliteProvider;
         this.isTorExitNode = isTorExitNode;
         this.isp = isp;
+        this.mobileCountryCode = mobileCountryCode;
+        this.mobileNetworkCode = mobileNetworkCode;
         this.network = network;
         this.organization = organization;
         this.userType = userType;
@@ -221,6 +295,8 @@ public final class Traits extends AbstractRecord {
             @MaxMindDbParameter(name="is_satellite_provider") Boolean isSatelliteProvider,
             @MaxMindDbParameter(name="is_tor_exit_node") Boolean isTorExitNode,
             @MaxMindDbParameter(name="isp") String isp,
+            @MaxMindDbParameter(name="mobile_country_code") String mobileCountryCode,
+            @MaxMindDbParameter(name="mobile_network_code") String mobileNetworkCode,
             @MaxMindDbParameter(name="network") Network network,
             @MaxMindDbParameter(name="organization") String organization,
             @MaxMindDbParameter(name="user_type") String userType,
@@ -243,6 +319,8 @@ public final class Traits extends AbstractRecord {
             isSatelliteProvider != null ? isSatelliteProvider : false,
             isTorExitNode != null ? isTorExitNode : false,
             isp,
+            mobileCountryCode,
+            mobileNetworkCode,
             network,
             organization,
             userType,
@@ -272,6 +350,8 @@ public final class Traits extends AbstractRecord {
             traits.isSatelliteProvider(),
             traits.isTorExitNode(),
             traits.getIsp(),
+            traits.getMobileCountryCode(),
+            traits.getMobileNetworkCode(),
             network,
             traits.getOrganization(),
             traits.getUserType(),
@@ -459,6 +539,26 @@ public final class Traits extends AbstractRecord {
     @JsonProperty("is_tor_exit_node")
     public boolean isTorExitNode() {
         return this.isTorExitNode;
+    }
+
+    /**
+     * @return The <a href="https://en.wikipedia.org/wiki/Mobile_country_code">
+     * mobile country code (MCC)</a> associated with the IP address and ISP.
+     * This property is available from the City and Insights web services and
+     * the GeoIP2 Enterprise database.
+     */
+    public String getMobileCountryCode() {
+        return this.mobileCountryCode;
+    }
+
+    /**
+     * @return The <a href="https://en.wikipedia.org/wiki/Mobile_country_code">
+     * mobile network code (MNC)</a> associated with the IP address and ISP.
+     * This property is available from the City and Insights web services and
+     * the GeoIP2 Enterprise database.
+     */
+    public String getMobileNetworkCode() {
+        return this.mobileNetworkCode;
     }
 
     /**

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -63,6 +63,7 @@ public final class Traits extends AbstractRecord {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -83,6 +84,7 @@ public final class Traits extends AbstractRecord {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -105,6 +107,7 @@ public final class Traits extends AbstractRecord {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -133,6 +136,7 @@ public final class Traits extends AbstractRecord {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -166,6 +170,7 @@ public final class Traits extends AbstractRecord {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public Traits(
             Integer autonomousSystemNumber,
             String autonomousSystemOrganization,
@@ -200,6 +205,7 @@ public final class Traits extends AbstractRecord {
      * @deprecated This constructor exists for backwards compatibility. Will be
      * removed in the next major release.
      */
+    @Deprecated
     public Traits(
             Long autonomousSystemNumber,
             String autonomousSystemOrganization,

--- a/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
+++ b/src/test/java/com/maxmind/geoip2/DatabaseReaderTest.java
@@ -349,6 +349,11 @@ public class DatabaseReaderTest {
             EnterpriseResponse tryResponse = reader.tryEnterprise(ipAddress).get();
             assertEquals(response.toJson(), tryResponse.toJson());
 
+            ipAddress = InetAddress.getByName("149.101.100.0");
+            response = reader.enterprise(ipAddress);
+            assertEquals("310", response.getTraits().getMobileCountryCode());
+            assertEquals("004", response.getTraits().getMobileNetworkCode());
+
             // Test that the city and country methods can be called without
             // an exception
             reader.city(ipAddress);
@@ -374,6 +379,11 @@ public class DatabaseReaderTest {
 
             IspResponse tryResponse = reader.tryIsp(ipAddress).get();
             assertEquals(response.toJson(), tryResponse.toJson());
+
+            ipAddress = InetAddress.getByName("149.101.100.0");
+            response = reader.isp(ipAddress);
+            assertEquals("310", response.getMobileCountryCode());
+            assertEquals("004", response.getMobileNetworkCode());
         }
     }
 

--- a/src/test/java/com/maxmind/geoip2/model/JsonTest.java
+++ b/src/test/java/com/maxmind/geoip2/model/JsonTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.jr.ob.JSON;
 import org.junit.Test;
 
@@ -338,8 +339,9 @@ public class JsonTest {
     protected <T extends AbstractResponse> void testRoundTrip
             (Class<T> cls, String json)
             throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
+        JsonMapper mapper = JsonMapper.builder()
+                .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
+                .build();
         InjectableValues inject = new InjectableValues.Std().addValue(
                 "locales", Collections.singletonList("en"));
         T response = mapper.readerFor(cls).with(inject).readValue(json);


### PR DESCRIPTION
- Update test databases
- Explicitly deprecate some constructors
- Bump copyright year
- Add MCC/MNC support
- Do not use deprecated ObjectMapper methods
- Do not use deprecated JUnit exception testing
- test on Java 16 & 17
