### PR TITLE
Bump jackson-databind to 2.23.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.2</version>
+            <version>2.13.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Bump jackson-databind to 2.13.2.1 which fixes [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518)

