### PR TITLE
Fix comment in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ InetAddress ipAddress = InetAddress.getByName("128.101.101.101");
 
 DomainResponse response = reader.domain(ipAddress);
 
-System.out.println(response.getDomain()); // 'Corporate'
+System.out.println(response.getDomain()); // 'umn.edu'
 ```
 
 ### Enterprise ###


### PR DESCRIPTION
This PR fixes comment in domain example.

`DomainResponse.getDomain` returns domain.