### PR TITLE
Remove ossrh-snapshots repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,11 +233,6 @@
             </plugin>
         </plugins>
     </build>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
     <profiles>
         <profile>
             <id>active-on-jdk-9-plus</id>


### PR DESCRIPTION
Dependabot will stop looking for maven dependencies once it finds a repository that returns any number of results, even if none of those results match the requested version. This removes the ossrh repository because it brings in snapshot repositories that prevent dependabot from falling back to the central repository. See: dependabot/dependabot-core#5872