### PR TITLE
Make docs more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ the Sandbox GeoIP2 web services intead of the production GeoIP2 web
 services, set the `host` method on the builder to `sandbox.maxmind.com`.
 You may also set a `timeout` or set the `locales` fallback order using the
 methods on the `Builder`. After you have created the `WebServiceClient`,
-you may then call the method corresponding to a specific end point, passing
+you may then call the method corresponding to a specific web service, passing
 it the IP address you want to look up.
 
 If the request succeeds, the method call will return a model class for the end
@@ -465,17 +465,16 @@ we suggest creating one object and sharing that across threads.
 
 ## What data is returned? ##
 
-While many of the end points return the same basic records, the attributes
-which can be populated vary between end points. In addition, while an end
-point may offer a particular piece of data, MaxMind does not always have every
-piece of data for any given IP address.
+While many of the location databases and web services return the same
+basic records, the attributes poplulated can vary. In addition, MaxMind does
+not always have every piece of data for any given IP address.
 
-Because of these factors, it is possible for any end point to return a record
+Because of these factors, it is possible for any web service to return a record
 where some or all of the attributes are unpopulated.
 
 [See our web-service developer
 documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en) for
-details on what data each end point may return.
+details on what data each web service may return.
 
 The only piece of data which is always returned is the `ip_address`
 available at `lookup.getTraits().getIpAddress()`.

--- a/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
+++ b/src/main/java/com/maxmind/geoip2/record/AbstractNamedRecord.java
@@ -27,8 +27,7 @@ public abstract class AbstractNamedRecord extends AbstractRecord {
     }
 
     /**
-     * @return The GeoName ID for the city. This attribute is returned by all
-     * end points.
+     * @return The GeoName ID for the city.
      */
     @JsonProperty("geoname_id")
     public Long getGeoNameId() {
@@ -37,8 +36,7 @@ public abstract class AbstractNamedRecord extends AbstractRecord {
 
     /**
      * @return The name of the city based on the locales list passed to the
-     * {@link com.maxmind.geoip2.WebServiceClient} constructor. This
-     * attribute is returned by all end points.
+     * constructor.
      */
     @JsonIgnore
     public String getName() {
@@ -51,8 +49,7 @@ public abstract class AbstractNamedRecord extends AbstractRecord {
     }
 
     /**
-     * @return A {@link Map} from locale codes to the name in that locale. This
-     * attribute is returned by all end points.
+     * @return A {@link Map} from locale codes to the name in that locale.
      */
     @JsonProperty("names")
     public Map<String, String> getNames() {

--- a/src/main/java/com/maxmind/geoip2/record/City.java
+++ b/src/main/java/com/maxmind/geoip2/record/City.java
@@ -12,9 +12,6 @@ import java.util.Map;
  * City-level data associated with an IP address.
  * </p>
  * <p>
- * This record is returned by all the end points except the Country end point.
- * </p>
- * <p>
  * Do not use any of the city names as a database or map key. Use the value
  * returned by {@link #getGeoNameId} instead.
  * </p>
@@ -53,7 +50,7 @@ public final class City extends AbstractNamedRecord {
     /**
      * @return A value from 0-100 indicating MaxMind's confidence that the city
      * is correct. This attribute is only available from the Insights
-     * end point and the GeoIP2 Enterprise database.
+     * web service and the GeoIP2 Enterprise database.
      */
     public Integer getConfidence() {
         return this.confidence;

--- a/src/main/java/com/maxmind/geoip2/record/Continent.java
+++ b/src/main/java/com/maxmind/geoip2/record/Continent.java
@@ -12,9 +12,6 @@ import java.util.Map;
  * Contains data for the continent record associated with an IP address.
  * </p>
  * <p>
- * This record is returned by all the end points.
- * </p>
- * <p>
  * Do not use any of the continent names as a database or map key. Use the
  * value returned by {@link #getGeoNameId} or {@link #getCode} instead.
  * </p>
@@ -52,7 +49,7 @@ public final class Continent extends AbstractNamedRecord {
 
     /**
      * @return A two character continent code like "NA" (North America) or "OC"
-     * (Oceania). This attribute is returned by all end points.
+     * (Oceania).
      */
     public String getCode() {
         return this.code;

--- a/src/main/java/com/maxmind/geoip2/record/Country.java
+++ b/src/main/java/com/maxmind/geoip2/record/Country.java
@@ -12,9 +12,6 @@ import java.util.Map;
  * Contains data for the country record associated with an IP address.
  * </p>
  * <p>
- * This record is returned by all the end points.
- * </p>
- * <p>
  * Do not use any of the country names as a database or map key. Use the value
  * returned by {@link #getGeoNameId} or {@link #getIsoCode} instead.
  * </p>
@@ -62,7 +59,7 @@ public class Country extends AbstractNamedRecord {
     /**
      * @return A value from 0-100 indicating MaxMind's confidence that the
      * country is correct. This attribute is only available from the
-     * Insights end point and the GeoIP2 Enterprise database.
+     * Insights web service and the GeoIP2 Enterprise database.
      */
     public Integer getConfidence() {
         return this.confidence;
@@ -70,8 +67,7 @@ public class Country extends AbstractNamedRecord {
 
     /**
      * @return This is true if the country is a member state of the European
-     * Union. This attribute is returned by all location services and
-     * databases.
+     * Union.
      */
     @JsonProperty("is_in_european_union")
     public boolean isInEuropeanUnion() {
@@ -81,12 +77,10 @@ public class Country extends AbstractNamedRecord {
     /**
      * @return The <a
      * href="https://en.wikipedia.org/wiki/ISO_3166-1">two-character ISO
-     * 3166-1 alpha code</a> for the country. This attribute is returned
-     * by all end points.
+     * 3166-1 alpha code</a> for the country.
      */
     @JsonProperty("iso_code")
     public String getIsoCode() {
         return this.isoCode;
     }
-
 }

--- a/src/main/java/com/maxmind/geoip2/record/Location.java
+++ b/src/main/java/com/maxmind/geoip2/record/Location.java
@@ -47,7 +47,8 @@ public class Location extends AbstractRecord {
 
     /**
      * @return The average income in US dollars associated with the requested
-     * IP address. This attribute is only available from the Insights end point.
+     * IP address. This attribute is only available from the Insights web
+     * service.
      */
     @JsonProperty("average_income")
     public Integer getAverageIncome() {
@@ -56,7 +57,8 @@ public class Location extends AbstractRecord {
 
     /**
      * @return The estimated population per square kilometer associated with the
-     * IP address. This attribute is only available from the Insights end point.
+     * IP address. This attribute is only available from the Insights web
+     * service.
      */
     @JsonProperty("population_density")
     public Integer getPopulationDensity() {

--- a/src/main/java/com/maxmind/geoip2/record/MaxMind.java
+++ b/src/main/java/com/maxmind/geoip2/record/MaxMind.java
@@ -8,9 +8,6 @@ import com.maxmind.db.MaxMindDbParameter;
  * <p>
  * Contains data related to your MaxMind account.
  * </p>
- * <p>
- * This record is returned by all the end points.
- * </p>
  */
 public final class MaxMind extends AbstractRecord {
 
@@ -29,7 +26,7 @@ public final class MaxMind extends AbstractRecord {
 
     /**
      * @return The number of remaining queried in your account for the current
-     * end point.
+     * web service. This returns {@code null} when called on a database.
      */
     @JsonProperty("queries_remaining")
     public Integer getQueriesRemaining() {

--- a/src/main/java/com/maxmind/geoip2/record/Postal.java
+++ b/src/main/java/com/maxmind/geoip2/record/Postal.java
@@ -8,9 +8,6 @@ import com.maxmind.db.MaxMindDbParameter;
  * <p>
  * Contains data for the postal record associated with an IP address.
  * </p>
- * <p>
- * This record is returned by all the end points except the Country end point.
- * </p>
  */
 public final class Postal extends AbstractRecord {
 
@@ -33,8 +30,7 @@ public final class Postal extends AbstractRecord {
     /**
      * @return The postal code of the location. Postal codes are not available
      * for all countries. In some countries, this will only contain part
-     * of the postal code. This attribute is returned by all end points
-     * except the Country end point.
+     * of the postal code.
      */
     public String getCode() {
         return this.code;
@@ -43,7 +39,7 @@ public final class Postal extends AbstractRecord {
     /**
      * @return A value from 0-100 indicating MaxMind's confidence that the
      * postal code is correct. This attribute is only available from the
-     * Insights end point and the GeoIP2 Enterprise database.
+     * Insights web service and the GeoIP2 Enterprise database.
      */
     public Integer getConfidence() {
         return this.confidence;

--- a/src/main/java/com/maxmind/geoip2/record/Subdivision.java
+++ b/src/main/java/com/maxmind/geoip2/record/Subdivision.java
@@ -12,9 +12,6 @@ import java.util.Map;
  * Contains data for the subdivisions associated with an IP address.
  * </p>
  * <p>
- * This record is returned by all the end points except the Country end point.
- * </p>
- * <p>
  * Do not use any of the subdivision names as a database or map key. Use the
  * value returned by {@link #getGeoNameId} or {@link #getIsoCode} instead.
  * </p>
@@ -57,7 +54,7 @@ public final class Subdivision extends AbstractNamedRecord {
     /**
      * @return This is a value from 0-100 indicating MaxMind's confidence that
      * the subdivision is correct. This attribute is only available from
-     * the Insights end point and the GeoIP2 Enterprise database.
+     * the Insights web service and the GeoIP2 Enterprise database.
      */
     @JsonProperty("confidence")
     public Integer getConfidence() {
@@ -68,8 +65,7 @@ public final class Subdivision extends AbstractNamedRecord {
      * @return This is a string up to three characters long contain the
      * subdivision portion of the <a
      * href="https://en.wikipedia.org/wiki/ISO_3166-2">ISO
-     * 3166-2code</a>. This attribute is returned by all end points
-     * except Country.
+     * 3166-2code</a>.
      */
     @JsonProperty("iso_code")
     public String getIsoCode() {

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -254,8 +254,7 @@ public final class Traits extends AbstractRecord {
      * performed a "me" lookup against the web service, this will be the
      * externally routable IP address for the system the code is running
      * on. If the system is behind a NAT, this may differ from the IP
-     * address locally assigned to it. This is available from all web
-     * services and databases.
+     * address locally assigned to it.
      */
     @JsonProperty("ip_address")
     public String getIpAddress() {

--- a/src/main/java/com/maxmind/geoip2/record/Traits.java
+++ b/src/main/java/com/maxmind/geoip2/record/Traits.java
@@ -280,8 +280,7 @@ public final class Traits extends AbstractRecord {
     }
 
     /**
-     * @return This is true if the IP is an anonymous proxy. This is available
-     * from all web services and databases.
+     * @return This is true if the IP is an anonymous proxy.
      * @deprecated Use our
      * <a href="https://www.maxmind.com/en/geoip2-anonymous-ip-database">GeoIP2
      * Anonymous IP database</a> instead.
@@ -345,7 +344,6 @@ public final class Traits extends AbstractRecord {
 
     /**
      * @return This is true if the IP belong to a satellite Internet provider.
-     * This is available from all web services and databases.
      * @deprecated Due to increased mobile usage, we have insufficient data to
      * maintain this field.
      */


### PR DESCRIPTION
In particular, use "web service" rather than "endpoint" everywhere. This more closely matches our other documentation. Also, removed comments about a value being available from all databases and web services as we did so inconsistently and it was noise. We now only mention if it is limited to particular databases or web services.

Closes #357.
