### PR TITLE
Add WebServiceProvider interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 4.2.0
 ------------------
 
+* A `WebServiceProvider` interface has been added to facilitate mocking of
+  `WebServiceClient`. Requested by Evan Chrisinger. GitHub #359.
 * The GeoIP2 IP Risk database has been discontinued. Methods and classes
   related to it have been deprecated.
 * The `fromString` static method on the `ConnectionType` enum now has

--- a/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseProvider.java
@@ -77,7 +77,9 @@ public interface DatabaseProvider extends GeoIp2Provider {
      * @return an IPRiskResponse for the requested IP address or empty if it is not in the DB.
      * @throws com.maxmind.geoip2.exception.GeoIp2Exception if there is an error looking up the IP
      * @throws java.io.IOException                          if there is an IO error
+     * @deprecated This database has been discontinued.
      */
+    @Deprecated
     Optional<IpRiskResponse> tryIpRisk(InetAddress ipAddress) throws IOException,
         GeoIp2Exception;
 

--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -455,6 +455,7 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
         return getIpRisk(ipAddress);
     }
 
+    @Deprecated
     private Optional<IpRiskResponse> getIpRisk(InetAddress ipAddress) throws IOException,
         GeoIp2Exception {
         LookupResult<IpRiskResponse> result = this.get(

--- a/src/main/java/com/maxmind/geoip2/DatabaseReader.java
+++ b/src/main/java/com/maxmind/geoip2/DatabaseReader.java
@@ -267,7 +267,7 @@ public class DatabaseReader implements DatabaseProvider, Closeable {
      */
     private <T> LookupResult<T> get(InetAddress ipAddress, Class<T> cls,
                                     DatabaseType expectedType)
-        throws IOException, AddressNotFoundException {
+        throws IOException {
 
         if ((databaseType & expectedType.type) == 0) {
             String caller = Thread.currentThread().getStackTrace()[3]

--- a/src/main/java/com/maxmind/geoip2/WebServiceClient.java
+++ b/src/main/java/com/maxmind/geoip2/WebServiceClient.java
@@ -107,7 +107,7 @@ import java.util.Map;
  * throws a {@link GeoIp2Exception}.
  * </p>
  */
-public class WebServiceClient implements GeoIp2Provider, Closeable {
+public class WebServiceClient implements WebServiceProvider, Closeable {
     private final String host;
     private final List<String> locales;
     private final String authHeader;

--- a/src/main/java/com/maxmind/geoip2/WebServiceProvider.java
+++ b/src/main/java/com/maxmind/geoip2/WebServiceProvider.java
@@ -1,0 +1,40 @@
+package com.maxmind.geoip2;
+
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import com.maxmind.geoip2.model.CityResponse;
+import com.maxmind.geoip2.model.CountryResponse;
+import com.maxmind.geoip2.model.InsightsResponse;
+import java.io.IOException;
+import java.net.InetAddress;
+
+public interface WebServiceProvider extends GeoIp2Provider {
+    /**
+     * @return A Country model for the requesting IP address
+     * @throws GeoIp2Exception if there is an error from the web service
+     * @throws IOException     if an IO error happens during the request
+     */
+    CountryResponse country() throws IOException, GeoIp2Exception;
+
+    /**
+     * @return A City model for the requesting IP address
+     * @throws GeoIp2Exception if there is an error from the web service
+     * @throws IOException     if an IO error happens during the request
+     */
+    CityResponse city() throws IOException, GeoIp2Exception;
+
+    /**
+     * @return An Insights model for the requesting IP address
+     * @throws GeoIp2Exception if there is an error from the web service
+     * @throws IOException     if an IO error happens during the request
+     */
+    InsightsResponse insights() throws IOException, GeoIp2Exception;
+
+    /**
+     * @param ipAddress IPv4 or IPv6 address to lookup.
+     * @return An Insight model for the requested IP address.
+     * @throws GeoIp2Exception if there is an error looking up the IP
+     * @throws IOException     if there is an IO error
+     */
+    InsightsResponse insights(InetAddress ipAddress) throws IOException,
+        GeoIp2Exception;
+}


### PR DESCRIPTION
- Add WebServiceProvider interface. Closes #359.
- Use try-with-resource in a couple more places
- Mark more IP Risk methods as deprecated
- Don't throws exception that method doesn't throw
