### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-4.2.0
+4.2.0 (2023-12-05)
 ------------------
 
 * A `WebServiceProvider` interface has been added to facilitate mocking of

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To do this, add the dependency to your pom.xml:
     <dependency>
         <groupId>com.maxmind.geoip2</groupId>
         <artifactId>geoip2</artifactId>
-        <version>4.1.0</version>
+        <version>4.2.0</version>
     </dependency>
 ```
 
@@ -30,7 +30,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.maxmind.geoip2:geoip2:4.1.0'
+    compile 'com.maxmind.geoip2:geoip2:4.2.0'
 }
 ```
 

--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -124,6 +124,3 @@ git push --tags
 gh release create --target "$(git branch --show-current)" -t "$version" -n "$notes" "$tag" \
     "target/geoip2-$version-with-dependencies.zip" \
     "target/geoip2-$version-with-dependencies.zip.asc"
-
-
-echo "Remember to do the release on https://oss.sonatype.org/!"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.maxmind.geoip2</groupId>
     <artifactId>geoip2</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.2.0</version>
     <packaging>jar</packaging>
     <name>MaxMind GeoIP2 API</name>
     <description>GeoIP2 webservice client and database reader</description>
@@ -23,7 +23,8 @@
         <url>https://github.com/maxmind/GeoIP2-java</url>
         <connection>scm:git:git://github.com:maxmind/GeoIP2-java.git</connection>
         <developerConnection>scm:git:git@github.com:maxmind/GeoIP2-java.git</developerConnection>
-    </scm>
+      <tag>v4.2.0</tag>
+  </scm>
     <issueManagement>
         <url>https://github.com/maxmind/GeoIP2-java/issues</url>
         <system>GitHub</system>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.maxmind.db</groupId>
             <artifactId>maxmind-db</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.11.0</version>
                         <configuration>
                             <release>11</release>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.maxmind.geoip2</groupId>
     <artifactId>geoip2</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>MaxMind GeoIP2 API</name>
     <description>GeoIP2 webservice client and database reader</description>
@@ -23,7 +23,7 @@
         <url>https://github.com/maxmind/GeoIP2-java</url>
         <connection>scm:git:git://github.com:maxmind/GeoIP2-java.git</connection>
         <developerConnection>scm:git:git@github.com:maxmind/GeoIP2-java.git</developerConnection>
-      <tag>v4.2.0</tag>
+      <tag>HEAD</tag>
   </scm>
     <issueManagement>
         <url>https://github.com/maxmind/GeoIP2-java/issues</url>

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,33 @@
                 <version>3.2.2</version>
             </plugin>
             <plugin>
+                <!--
+                    We need this for updating the submodule during release. Maven SCM
+                    doesn't support this itself apparently. See
+                    https://github.com/apache/maven-scm/pull/179
+                -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <!--
+                    We are using 3.0.0 as 3.1.1 fails due to this issue:
+                    https://github.com/mojohaus/exec-maven-plugin/issues/373
+                -->
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <id>invoke build</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>git</executable>
+                    <commandlineArgs>submodule update --init --recursive</commandlineArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>2.16.2</version>


### PR DESCRIPTION
- Add back exec-maven-plugin
- Set maven-compiler-plugin version
- Remove reminder to do release on oss.sonatype.org
- Upgrade maxmind-db to 3.1.0
- Set release date
- update version number in README.md
- [maven-release-plugin] prepare release v4.2.0
- [maven-release-plugin] prepare for next development iteration
