### PR TITLE
Added `reflect-config.json` required to support graalvm native-image build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.maxmind.db</groupId>
             <artifactId>maxmind-db</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/resources/META-INF/native-image/com.maxmind.geoip2/geoip2/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/com.maxmind.geoip2/geoip2/reflect-config.json
@@ -1,0 +1,178 @@
+[
+  {
+    "name": "com.maxmind.geoip2.model.AbstractCityResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.AbstractCountryResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.AbstractResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.AnonymousIpResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.AsnResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.CityResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.ConnectionTypeResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.CountryResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.DomainResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.EnterpriseResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.InsightsResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.IpBaseResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.IpRiskResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.model.IspResponse",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  
+  {
+    "name": "com.maxmind.geoip2.record.AbstractNamedRecord",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.AbstractRecord",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.City",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.Continent",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.Country",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.Location",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.MaxMind",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.Postal",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.RepresentedCountry",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.Subdivision",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.maxmind.geoip2.record.Traits",
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  }
+]


### PR DESCRIPTION
This PR, together with https://github.com/maxmind/MaxMind-DB-Reader-java/pull/166 adds full `native-image` support in `geoip2-java`. 

Previously application, incorportaing `geoip2-java` threw exception when attempt was made to resolve some address:

```
com.maxmind.db.ConstructorNotFoundException: No constructor on class com.maxmind.geoip2.model.CityResponse with the MaxMindDbConstructor annotation was found.
        at com.maxmind.db.Decoder.findConstructor(Decoder.java:473)
        at com.maxmind.db.Decoder.decodeMapIntoObject(Decoder.java:394)
        at com.maxmind.db.Decoder.decodeMap(Decoder.java:341)
        at com.maxmind.db.Decoder.decodeByType(Decoder.java:162)
        at com.maxmind.db.Decoder.decode(Decoder.java:151)
        at com.maxmind.db.Decoder.decode(Decoder.java:76)
        at com.maxmind.db.Reader.resolveDataPointer(Reader.java:413)
        at com.maxmind.db.Reader.getRecord(Reader.java:185)
        at com.maxmind.geoip2.DatabaseReader.get(DatabaseReader.java:280)
        at com.maxmind.geoip2.DatabaseReader.getCity(DatabaseReader.java:365)
        at com.maxmind.geoip2.DatabaseReader.tryCity(DatabaseReader.java:359)
 ```
 
 **NOTE**: This PR requires new release of `maxmind/MaxMind-DB-Reader-java` with native-image support.