### PR TITLE
Add httpClient() method to WebServiceClient.Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+4.4.0
+------------------
+
+* `WebServiceClient.Builder` now has an `httpClient()` method to allow
+  passing in a custom `HttpClient`.
+
 4.3.1 (2025-05-28)
 ------------------
 


### PR DESCRIPTION
This allows users to provide a custom HttpClient for full control over client configuration. When a custom HttpClient is provided, the builder validates that conflicting parameters (connectTimeout, proxy) are not also set, ensuring clear configuration ownership.

🤖 Generated with [Claude Code](https://claude.ai/code)