### PR TITLE
Set Dependabot cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,21 @@
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "14:00"
-  open-pull-requests-limit: 10
-  groups:
-    jackson:
-      patterns:
-        - "com.fasterxml.jackson*"
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "14:00"
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: daily
+      time: '14:00'
+    open-pull-requests-limit: 10
+    groups:
+      jackson:
+        patterns:
+          - com.fasterxml.jackson*
+    cooldown:
+      default-days: 4
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: '14:00'
+    cooldown:
+      default-days: 4


### PR DESCRIPTION
This PR sets the Dependabot cooldown period to 4 days for all package ecosystems.

## Context

This addresses zizmor findings that flag missing or insufficient cooldown configuration in dependabot.yml files. The zizmor security tool requires a minimum cooldown of 4 days to avoid potential security issues with rapid dependency updates.

## Changes

- Added/updated `cooldown` configuration with `default-days: 4` for all package ecosystems in `.github/dependabot.yml`

## References

- Linear issue: [ENG-3236](https://linear.app/maxmind/issue/ENG-3236/zizmor-findings-are-addressed)
- zizmor documentation: https://docs.zizmor.sh/audits/#remediation_6
