### PR TITLE
Add branch validation checks to release script

### DIFF
--- a/dev-bin/release.sh
+++ b/dev-bin/release.sh
@@ -10,6 +10,16 @@ if [ "$current_branch" = "main" ]; then
     exit 1
 fi
 
+# Fetch latest changes and check that we're not behind origin/main
+echo "Fetching from origin..."
+git fetch origin
+
+if ! git merge-base --is-ancestor origin/main HEAD; then
+    echo "Error: Current branch is behind origin/main."
+    echo "Please merge or rebase with origin/main before releasing."
+    exit 1
+fi
+
 changelog=$(cat CHANGELOG.md)
 
 regex='


### PR DESCRIPTION
Add safety checks to prevent broken releases:
- Check that releases are not run directly on the main branch
- Check that the release branch contains all commits from origin/main

Fixes ENG-3512