### PR TITLE
Validate and update links (STF-557)

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,32 @@
+name: Links
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 13 * * 1" # weekly, to catch external link rot without a commit
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup mise
+        uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+        with:
+          install: false
+
+      # Install only lychee (not the repo's full toolchain) and run the check.
+      - name: Check links
+        env:
+          MISE_AUTO_INSTALL: "false"
+        run: |
+          mise install lychee
+          mise run check-links

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pom.xml.versionsBackup
 target
 reports
 Test.java
+.lycheecache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,7 +397,7 @@ public interface JsonSerializable {
 ## Additional Resources
 
 - [API Documentation](https://maxmind.github.io/GeoIP2-java/)
-- [GeoIP Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services)
+- [GeoIP Web Services Docs](https://dev.maxmind.com/geoip/docs/web-services/)
 - [MaxMind DB Format](https://maxmind.github.io/MaxMind-DB/)
 - GitHub Issues: https://github.com/maxmind/GeoIP2-java/issues
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Description ##
 
 This distribution provides an API for the GeoIP and GeoLite [web
-services](https://dev.maxmind.com/geoip/docs/web-services?lang=en) and
-[databases](https://dev.maxmind.com/geoip/docs/databases?lang=en).
+services](https://dev.maxmind.com/geoip/docs/web-services/?lang=en) and
+[databases](https://dev.maxmind.com/geoip/docs/databases/?lang=en).
 
 ## Installation ##
 
@@ -491,7 +491,7 @@ try (DatabaseReader reader = new DatabaseReader.Builder(database).build()) {
 
 For details on the possible errors returned by the web service itself, [see
 the GeoIP web service
-documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en).
+documentation](https://dev.maxmind.com/geoip/docs/web-services/?lang=en).
 
 If the web service returns an explicit error document, this is thrown as an
 `AddressNotFoundException`, an `AuthenticationException`, an
@@ -537,7 +537,7 @@ Because of these factors, it is possible for any web service to return a record
 where some or all of the attributes are unpopulated.
 
 [See our web-service developer
-documentation](https://dev.maxmind.com/geoip/docs/web-services?lang=en) for
+documentation](https://dev.maxmind.com/geoip/docs/web-services/?lang=en) for
 details on what data each web service may return.
 
 The only piece of data which is always returned is the `ip_address`
@@ -562,7 +562,7 @@ the GeoNames premium data set.
 
 If the problem you find is that an IP address is incorrectly mapped,
 please
-[submit your correction to MaxMind](https://www.maxmind.com/en/correction).
+[submit your correction to MaxMind](https://www.maxmind.com/en/geoip-data-correction-request).
 
 If you find some other sort of mistake, like an incorrect spelling,
 please check [the GeoNames site](https://www.geonames.org/) first. Once
@@ -573,7 +573,7 @@ data set, it will be automatically incorporated into future MaxMind
 releases.
 
 If you are a paying MaxMind customer and you're not sure where to submit
-a correction, please [contact MaxMind support](https://www.maxmind.com/en/support)
+a correction, please [contact MaxMind support](https://support.maxmind.com/knowledge-base)
 for help.
 
 ## Other Support ##
@@ -583,7 +583,7 @@ Please report all issues with this code using the
 
 If you are having an issue with a MaxMind service that is not specific
 to the client API, please
-[contact MaxMind support](https://www.maxmind.com/en/support).
+[contact MaxMind support](https://support.maxmind.com/knowledge-base).
 
 ## Requirements  ##
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,64 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/#/usage/config
+#
+# Run locally with:
+#   lychee './**/*.md' './src/**/*.java' './pom.xml'
+
+# Include URL fragments in checks
+include_fragments = true
+
+# Don't allow any redirects, so links that have moved are surfaced and updated
+# to their canonical destination.
+max_redirects = 0
+
+# Accept these HTTP status codes
+# 100-103: Informational responses
+# 200-299: Success responses
+# 403: Forbidden (some sites use this for rate limiting)
+# 429: Too Many Requests
+# 500-599: Server errors (temporary issues shouldn't fail CI)
+# 999: LinkedIn's custom status code
+accept = ["100..=103", "200..=299", "403", "429", "500..=599", "999"]
+
+# Exclude URL patterns from checking (treated as regular expressions)
+exclude = [
+    '^file://',
+    # Live / auth-gated endpoints that appear as string literals or require login
+    '^https://geoip\.maxmind\.com',
+    '^https://geolite\.info',
+    '^https://minfraud\.maxmind\.com',
+    '^https://sandbox\.maxmind\.com',
+    '^https://updates\.maxmind\.com',
+    '^https://www\.maxmind\.com/en/accounts/',
+    'https://www\.maxmind\.com/en/account/login',
+    # XML namespace identifiers in pom.xml (not real links)
+    '^http://www\.w3\.org/',
+    '^http://maven\.apache\.org/',
+    '^https://maven\.apache\.org/xsd/',
+    '^http://java\.sun\.com/',
+    '^http://schemas\.',
+    # Maven property placeholder in a build-time download URL (not a real link)
+    'japicmp\.baselineVersion',
+    # Placeholders / local
+    '^https?://example\.(com|org|net)',
+    '^http://localhost',
+    '127\.0\.0\.1',
+]
+
+# Exclude file paths from getting checked (treated as regular expressions)
+exclude_path = [
+    '(^|/)node_modules/',
+    '(^|/)target/',
+    '(^|/)\.git/',
+    # Test fixtures (MaxMind-DB submodule) contain example URLs, not ours
+    '(^|/)src/test/resources/',
+    # Changelog: historical entries are preserved as-is, not rewritten
+    '(^|/)CHANGELOG\.md$',
+]
+
+# Cache results for 1 day to speed up repeated checks
+cache = true
+max_cache_age = "1d"
+
+# Skip missing input files instead of erroring
+skip_missing = true

--- a/mise.lock
+++ b/mise.lock
@@ -36,6 +36,34 @@ url = "https://github.com/gohugoio/hugo/releases/download/v0.161.1/hugo_0.161.1_
 version = "26.0.1"
 backend = "core:java"
 
+[[tools.lychee]]
+version = "0.23.0"
+backend = "aqua:lycheeverse/lychee"
+
+[tools.lychee."platforms.linux-arm64"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-arm64-musl"]
+checksum = "sha256:97eb93b02a7d78a752fc33e5b0983439ccaadbf3db952b68a0a4401acd92e6e0"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-aarch64-unknown-linux-gnu.tar.gz"
+
+[tools.lychee."platforms.linux-x64"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.linux-x64-musl"]
+checksum = "sha256:5538440d2c69a45a0a09983271e5dee0c2fe7137d8035d25b2632e10a66a090a"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-unknown-linux-musl.tar.gz"
+
+[tools.lychee."platforms.macos-arm64"]
+checksum = "sha256:4c8034900e11083b68ac6f6582c377ff1f704e268991999e09d717973e493e7f"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-arm64-macos.dmg"
+
+[tools.lychee."platforms.windows-x64"]
+checksum = "sha256:0fda7ff0a60c0250939fc25361c2d4e6e7853c31c996733fdd5a1dd760bcb824"
+url = "https://github.com/lycheeverse/lychee/releases/download/lychee-v0.23.0/lychee-x86_64-windows.exe"
+
 [[tools.maven]]
 version = "3.9.15"
 backend = "aqua:apache/maven"

--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,7 @@ disable_backends = [
 [tools]
 hugo = "latest"
 java = "latest"
+lychee = "latest"
 maven = "latest"
 
 [tasks.build-docs]
@@ -18,6 +19,10 @@ run = "hugo --source docs --minify"
 [tasks.serve-docs]
 description = "Serve the docs site locally with Hugo dev server"
 run = "hugo server --source docs"
+
+[tasks.check-links]
+description = "Check links with lychee"
+run = "lychee --no-progress './**/*.md' './src/**/*.java' './pom.xml'"
 
 [hooks]
 enter = "mise install --quiet --locked"

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <packaging>jar</packaging>
     <name>MaxMind GeoIP API</name>
     <description>GeoIP webservice client and database reader</description>
-    <url>https://dev.maxmind.com/geoip?lang=en</url>
+    <url>https://dev.maxmind.com/geoip/?lang=en</url>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -17,7 +17,7 @@
     </licenses>
     <organization>
         <name>MaxMind, Inc.</name>
-        <url>https://www.maxmind.com/</url>
+        <url>https://www.maxmind.com/en/home</url>
     </organization>
     <scm>
         <url>https://github.com/maxmind/GeoIP2-java</url>

--- a/src/main/java/com/maxmind/geoip2/WebServiceClient.java
+++ b/src/main/java/com/maxmind/geoip2/WebServiceClient.java
@@ -91,7 +91,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
  * <h2>Exceptions</h2>
  * <p>
  * For details on the possible errors returned by the web service itself, see <a
- * href="https://dev.maxmind.com/geoip/docs/web-services?lang=en">the GeoIP web
+ * href="https://dev.maxmind.com/geoip/docs/web-services/?lang=en">the GeoIP web
  * service documentation</a>.
  * </p>
  * <p>

--- a/src/main/java/com/maxmind/geoip2/model/CityResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/CityResponse.java
@@ -40,7 +40,7 @@ import java.util.List;
  *                     to most specific (smallest). If the response did not contain any
  *                     subdivisions, this is an empty list.
  * @param traits Record for the traits of the requested IP address.
- * @see <a href="https://dev.maxmind.com/geoip/docs/web-services?lang=en">GeoIP Web
+ * @see <a href="https://dev.maxmind.com/geoip/docs/web-services/?lang=en">GeoIP Web
  * Services</a>
  */
 public record CityResponse(

--- a/src/main/java/com/maxmind/geoip2/model/CountryResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/CountryResponse.java
@@ -25,7 +25,7 @@ import java.util.List;
  *                           represented country is used for things like military bases. It is
  *                           only present when the represented country differs from the country.
  * @param traits Record for the traits of the requested IP address.
- * @see <a href="https://dev.maxmind.com/geoip/docs/web-services?lang=en">GeoIP Web
+ * @see <a href="https://dev.maxmind.com/geoip/docs/web-services/?lang=en">GeoIP Web
  * Services</a>
  */
 public record CountryResponse(

--- a/src/main/java/com/maxmind/geoip2/model/InsightsResponse.java
+++ b/src/main/java/com/maxmind/geoip2/model/InsightsResponse.java
@@ -43,7 +43,7 @@ import java.util.List;
  *                     to most specific (smallest). If the response did not contain any
  *                     subdivisions, this is an empty list.
  * @param traits Record for the traits of the requested IP address.
- * @see <a href="https://dev.maxmind.com/geoip/docs/web-services?lang=en">GeoIP Web
+ * @see <a href="https://dev.maxmind.com/geoip/docs/web-services/?lang=en">GeoIP Web
  * Services</a>
  */
 public record InsightsResponse(


### PR DESCRIPTION
Validated every link in the repo with the [lychee](https://lychee.cli.rs/) link checker, fixed stale/redirecting links, and added a lychee config plus a Links CI workflow so future link rot is caught automatically.

## CI setup
- `lychee.toml` with `max_redirects = 0`, fragment checking, MaxMind live/auth and XML-namespace excludes, and `CHANGELOG.md` / `target` / test fixtures excluded from scanning.
- `.github/workflows/links.yml` runs on push, PR, weekly cron, and manual dispatch.
- `.lycheecache` added to `.gitignore`.

## Links updated (old -> new)
- `https://dev.maxmind.com/geoip?lang=en` -> `https://dev.maxmind.com/geoip/?lang=en` (pom.xml)
- `https://www.maxmind.com/` -> `https://www.maxmind.com/en/home` (pom.xml)
- `https://dev.maxmind.com/geoip/docs/web-services` -> `.../web-services/` (CLAUDE.md)
- `https://dev.maxmind.com/geoip/docs/web-services?lang=en` -> `.../web-services/?lang=en` (README.md, CityResponse.java, CountryResponse.java, InsightsResponse.java, WebServiceClient.java)
- `https://dev.maxmind.com/geoip/docs/databases?lang=en` -> `.../databases/?lang=en` (README.md)
- `https://www.maxmind.com/en/correction` -> `https://www.maxmind.com/en/geoip-data-correction-request` (README.md)
- `https://www.maxmind.com/en/support` -> `https://support.maxmind.com/knowledge-base` (README.md)

Each replacement was resolved with `curl` and confirmed to be a clean 200 with no further redirect.

Historical `CHANGELOG.md` entries are intentionally left unchanged (and excluded from scanning).

lychee ends green: `🔍 44 Total ✅ 37 OK 🚫 0 Errors 👻 7 Excluded`.

Part of STF-557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)